### PR TITLE
Rename parameters for improved clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ SET pg_track_optimizer.hash_mem = 10240;
 
 ```sql
 SELECT
-    querytext,
+    query,
     avg_error,
     rms_error,
     twa_error,
     wca_error,
-    nodes_assessed,
-    nodes_total,
+    evaluated_nodes,
+    plan_nodes,
     exec_time,
     nexecs
 FROM pg_track_optimizer()
@@ -127,21 +127,21 @@ LIMIT 10;
 
 **Example output:**
 ```
-                    querytext                     | avg_error | rms_error | twa_error | wca_error | nodes_assessed | nexecs
---------------------------------------------------+-----------+-----------+-----------+-----------+----------------+--------
- SELECT * FROM orders WHERE customer_id = $1      |      4.23 |      4.89 |      4.56 |      3.87 |              5 |    142
- SELECT COUNT(*) FROM products WHERE category...  |      3.87 |      4.12 |      3.95 |      4.21 |              3 |     23
+                    query                         | avg_error | rms_error | twa_error | wca_error | evaluated_nodes | nexecs
+--------------------------------------------------+-----------+-----------+-----------+-----------+-----------------+--------
+ SELECT * FROM orders WHERE customer_id = $1      |      4.23 |      4.89 |      4.56 |      3.87 |               5 |    142
+ SELECT COUNT(*) FROM products WHERE category...  |      3.87 |      4.12 |      3.95 |      4.21 |               3 |     23
 ```
 
 ### Column Descriptions
 
-- **querytext**: The SQL query (normalised, with literals replaced by `$1`, `$2`, etc.)
+- **query**: The SQL query (normalised, with literals replaced by `$1`, `$2`, etc.)
 - **avg_error**: Simple average of log-scale errors across plan nodes
 - **rms_error**: Root Mean Square (RMS) error - emphasises large estimation errors
 - **twa_error**: Time-Weighted Average (TWA) error - highlights estimation errors in time-consuming nodes
 - **wca_error**: Cost-Weighted Average (WCA) error - highlights estimation errors in nodes the planner considered expensive
-- **nodes_assessed**: Number of plan nodes analysed
-- **nodes_total**: Total plan nodes (some may be skipped, e.g., never-executed branches)
+- **evaluated_nodes**: Number of plan nodes analysed
+- **plan_nodes**: Total plan nodes (some may be skipped, e.g., never-executed branches)
 - **exec_time**: Total execution time across all executions (milliseconds)
 - **nexecs**: Number of times the query was executed
 
@@ -198,7 +198,7 @@ The extension will automatically track queries exceeding the error threshold. Pr
 ### 3. Review Worst Offenders
 ```sql
 SELECT
-    querytext,
+    query,
     avg_error,
     nexecs,
     exec_time / nexecs AS avg_time_ms

--- a/expected/interface.out
+++ b/expected/interface.out
@@ -1,19 +1,19 @@
 CREATE EXTENSION pg_track_optimizer;
 \d pg_track_optimizer
                   View "public.pg_track_optimizer"
-     Column     |       Type       | Collation | Nullable | Default 
-----------------+------------------+-----------+----------+---------
- dboid          | oid              |           |          | 
- queryid        | bigint           |           |          | 
- querytext      | text             |           |          | 
- avg_error      | double precision |           |          | 
- rms_error      | double precision |           |          | 
- twa_error      | double precision |           |          | 
- wca_error      | double precision |           |          | 
- nodes_assessed | integer          |           |          | 
- nodes_total    | integer          |           |          | 
- exec_time      | double precision |           |          | 
- nexecs         | bigint           |           |          | 
+     Column      |       Type       | Collation | Nullable | Default 
+-----------------+------------------+-----------+----------+---------
+ dboid           | oid              |           |          | 
+ queryid         | bigint           |           |          | 
+ query           | text             |           |          | 
+ avg_error       | double precision |           |          | 
+ rms_error       | double precision |           |          | 
+ twa_error       | double precision |           |          | 
+ wca_error       | double precision |           |          | 
+ evaluated_nodes | integer          |           |          | 
+ plan_nodes      | integer          |           |          | 
+ exec_time       | double precision |           |          | 
+ nexecs          | bigint           |           |          | 
 
 \df pg_track_optimizer_flush
                                  List of functions

--- a/expected/join_filtering.out
+++ b/expected/join_filtering.out
@@ -49,21 +49,21 @@ WHERE join_outer.val + join_inner.val > 5;
 (5 rows)
 
 -- Check that we tracked the query
--- The nodes_assessed should include the join node with filtered tuples
+-- The evaluated_nodes should include the join node with filtered tuples
 SELECT
-  querytext,
+  query,
   ROUND(avg_error::numeric,1) AS error,
-  nodes_assessed,
-  nodes_total,
+  evaluated_nodes,
+  plan_nodes,
   nexecs
 FROM pg_track_optimizer()
-WHERE querytext LIKE '%FROM join_outer%';
-                             querytext                              | error | nodes_assessed | nodes_total | nexecs 
---------------------------------------------------------------------+-------+----------------+-------------+--------
- EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF)+|   0.3 |              3 |           3 |      1
- SELECT * FROM join_outer                                          +|       |                |             | 
- JOIN join_inner ON join_outer.id = join_inner.id                  +|       |                |             | 
- WHERE join_outer.val + join_inner.val > 5;                         |       |                |             | 
+WHERE query LIKE '%FROM join_outer%';
+                               query                                | error | evaluated_nodes | plan_nodes | nexecs 
+--------------------------------------------------------------------+-------+-----------------+------------+--------
+ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF)+|   0.3 |               3 |          3 |      1
+ SELECT * FROM join_outer                                          +|       |                 |            | 
+ JOIN join_inner ON join_outer.id = join_inner.id                  +|       |                 |            | 
+ WHERE join_outer.val + join_inner.val > 5;                         |       |                 |            | 
 (1 row)
 
 -- Cleanup

--- a/expected/join_filtering_1.out
+++ b/expected/join_filtering_1.out
@@ -49,21 +49,21 @@ WHERE join_outer.val + join_inner.val > 5;
 (5 rows)
 
 -- Check that we tracked the query
--- The nodes_assessed should include the join node with filtered tuples
+-- The evaluated_nodes should include the join node with filtered tuples
 SELECT
-  querytext,
+  query,
   ROUND(avg_error::numeric,1) AS error,
-  nodes_assessed,
-  nodes_total,
+  evaluated_nodes,
+  plan_nodes,
   nexecs
 FROM pg_track_optimizer()
-WHERE querytext LIKE '%FROM join_outer%';
-                             querytext                              | error | nodes_assessed | nodes_total | nexecs 
---------------------------------------------------------------------+-------+----------------+-------------+--------
- EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF)+|   0.3 |              3 |           3 |      1
- SELECT * FROM join_outer                                          +|       |                |             | 
- JOIN join_inner ON join_outer.id = join_inner.id                  +|       |                |             | 
- WHERE join_outer.val + join_inner.val > 5;                         |       |                |             | 
+WHERE query LIKE '%FROM join_outer%';
+                               query                                | error | evaluated_nodes | plan_nodes | nexecs 
+--------------------------------------------------------------------+-------+-----------------+------------+--------
+ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF)+|   0.3 |               3 |          3 |      1
+ SELECT * FROM join_outer                                          +|       |                 |            | 
+ JOIN join_inner ON join_outer.id = join_inner.id                  +|       |                 |            | 
+ WHERE join_outer.val + join_inner.val > 5;                         |       |                 |            | 
 (1 row)
 
 -- Cleanup

--- a/expected/pg_track_optimizer.out
+++ b/expected/pg_track_optimizer.out
@@ -22,13 +22,13 @@ EXPLAIN (COSTS OFF) SELECT * FROM pto_test WHERE x < 1;
    Filter: (x < 1)
 (2 rows)
 
-SELECT querytext,avg_error>=0,nodes_assessed,nodes_total,exec_time>0,nexecs
+SELECT query,avg_error>=0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
 FROM pg_track_optimizer()
-ORDER BY querytext COLLATE "C"; -- Nothing to track for plain explain.
-                 querytext                 | ?column? | nodes_assessed | nodes_total | ?column? | nexecs 
--------------------------------------------+----------+----------------+-------------+----------+--------
- SELECT * FROM pg_track_optimizer_flush(); | t        |              1 |           1 | t        |      1
- SELECT * FROM pg_track_optimizer_reset(); | t        |              1 |           1 | t        |      1
+ORDER BY query COLLATE "C"; -- Nothing to track for plain explain.
+                   query                   | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
+-------------------------------------------+----------+-----------------+------------+----------+--------
+ SELECT * FROM pg_track_optimizer_flush(); | t        |               1 |          1 | t        |      1
+ SELECT * FROM pg_track_optimizer_reset(); | t        |               1 |          1 | t        |      1
 (2 rows)
 
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
@@ -39,18 +39,18 @@ SELECT * FROM pto_test WHERE x < 1;
    Filter: (x < 1)
 (2 rows)
 
-SELECT querytext,avg_error>=0,nodes_assessed,nodes_total,exec_time>0,nexecs
+SELECT query,avg_error>=0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
 FROM pg_track_optimizer()
-ORDER BY querytext; -- Must see it.
-                                  querytext                                  | ?column? | nodes_assessed | nodes_total | ?column? | nexecs 
------------------------------------------------------------------------------+----------+----------------+-------------+----------+--------
- EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)                      +| t        |              1 |           1 | t        |      1
- SELECT * FROM pto_test WHERE x < 1;                                         |          |                |             |          | 
- SELECT * FROM pg_track_optimizer_flush();                                   | t        |              1 |           1 | t        |      1
- SELECT * FROM pg_track_optimizer_reset();                                   | t        |              1 |           1 | t        |      1
- SELECT querytext,avg_error>=0,nodes_assessed,nodes_total,exec_time>0,nexecs+| t        |              2 |           2 | t        |      1
- FROM pg_track_optimizer()                                                  +|          |                |             |          | 
- ORDER BY querytext COLLATE "C";                                             |          |                |             |          | 
+ORDER BY query; -- Must see it.
+                                  query                                  | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
+-------------------------------------------------------------------------+----------+-----------------+------------+----------+--------
+ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)                  +| t        |               1 |          1 | t        |      1
+ SELECT * FROM pto_test WHERE x < 1;                                     |          |                 |            |          | 
+ SELECT * FROM pg_track_optimizer_flush();                               | t        |               1 |          1 | t        |      1
+ SELECT * FROM pg_track_optimizer_reset();                               | t        |               1 |          1 | t        |      1
+ SELECT query,avg_error>=0,evaluated_nodes,plan_nodes,exec_time>0,nexecs+| t        |               2 |          2 | t        |      1
+ FROM pg_track_optimizer()                                              +|          |                 |            |          | 
+ ORDER BY query COLLATE "C";                                             |          |                 |            |          | 
 (4 rows)
 
 -- TODO: Disable storing of queries, involving the extension UI objects
@@ -60,21 +60,21 @@ SELECT * FROM pto_test WHERE x < 1;
 (0 rows)
 
 -- Must see second execution of the query in nexecs (don't mind EXPLAIN)
-SELECT querytext,avg_error>=0,nodes_assessed,nodes_total,exec_time>0,nexecs
+SELECT query,avg_error>=0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
 FROM pg_track_optimizer()
-ORDER BY querytext;
-                                  querytext                                  | ?column? | nodes_assessed | nodes_total | ?column? | nexecs 
------------------------------------------------------------------------------+----------+----------------+-------------+----------+--------
- EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)                      +| t        |              1 |           1 | t        |      2
- SELECT * FROM pto_test WHERE x < 1;                                         |          |                |             |          | 
- SELECT * FROM pg_track_optimizer_flush();                                   | t        |              1 |           1 | t        |      1
- SELECT * FROM pg_track_optimizer_reset();                                   | t        |              1 |           1 | t        |      1
- SELECT querytext,avg_error>=0,nodes_assessed,nodes_total,exec_time>0,nexecs+| t        |              2 |           2 | t        |      1
- FROM pg_track_optimizer()                                                  +|          |                |             |          | 
- ORDER BY querytext COLLATE "C";                                             |          |                |             |          | 
- SELECT querytext,avg_error>=0,nodes_assessed,nodes_total,exec_time>0,nexecs+| t        |              2 |           2 | t        |      1
- FROM pg_track_optimizer()                                                  +|          |                |             |          | 
- ORDER BY querytext;                                                         |          |                |             |          | 
+ORDER BY query;
+                                  query                                  | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
+-------------------------------------------------------------------------+----------+-----------------+------------+----------+--------
+ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)                  +| t        |               1 |          1 | t        |      2
+ SELECT * FROM pto_test WHERE x < 1;                                     |          |                 |            |          | 
+ SELECT * FROM pg_track_optimizer_flush();                               | t        |               1 |          1 | t        |      1
+ SELECT * FROM pg_track_optimizer_reset();                               | t        |               1 |          1 | t        |      1
+ SELECT query,avg_error>=0,evaluated_nodes,plan_nodes,exec_time>0,nexecs+| t        |               2 |          2 | t        |      1
+ FROM pg_track_optimizer()                                              +|          |                 |            |          | 
+ ORDER BY query COLLATE "C";                                             |          |                 |            |          | 
+ SELECT query,avg_error>=0,evaluated_nodes,plan_nodes,exec_time>0,nexecs+| t        |               2 |          2 | t        |      1
+ FROM pg_track_optimizer()                                              +|          |                 |            |          | 
+ ORDER BY query;                                                         |          |                 |            |          | 
 (5 rows)
 
 /*
@@ -100,12 +100,12 @@ SELECT * FROM t1;
    ->  Parallel Seq Scan on t1 (actual rows=20000.00 loops=5)
 (4 rows)
 
-SELECT querytext,avg_error,rms_error,nodes_assessed,nodes_total,nexecs
-FROM pg_track_optimizer() WHERE querytext LIKE '%FROM t1%';
-                             querytext                              | avg_error | rms_error | nodes_assessed | nodes_total | nexecs 
---------------------------------------------------------------------+-----------+-----------+----------------+-------------+--------
- EXPLAIN (COSTS OFF, ANALYZE, BUFFERS OFF, TIMING OFF, SUMMARY OFF)+|         0 |         0 |              2 |           2 |      1
- SELECT * FROM t1;                                                  |           |           |                |             | 
+SELECT query,avg_error,rms_error,evaluated_nodes,plan_nodes,nexecs
+FROM pg_track_optimizer() WHERE query LIKE '%FROM t1%';
+                               query                                | avg_error | rms_error | evaluated_nodes | plan_nodes | nexecs 
+--------------------------------------------------------------------+-----------+-----------+-----------------+------------+--------
+ EXPLAIN (COSTS OFF, ANALYZE, BUFFERS OFF, TIMING OFF, SUMMARY OFF)+|         0 |         0 |               2 |          2 |      1
+ SELECT * FROM t1;                                                  |           |           |                 |            | 
 (1 row)
 
 /*
@@ -143,12 +143,12 @@ SELECT val FROM verify_test;
 -- a more understandable manner.
 -- So, make this test helpful in the future ...
 SELECT
-  querytext,nodes_assessed,nodes_total,nexecs
-FROM pg_track_optimizer() WHERE querytext LIKE '%FROM verify_test%';
-                             querytext                              | nodes_assessed | nodes_total | nexecs 
---------------------------------------------------------------------+----------------+-------------+--------
- EXPLAIN (COSTS OFF, ANALYZE, BUFFERS OFF, TIMING OFF, SUMMARY OFF)+|              2 |           2 |      1
- SELECT val FROM verify_test;                                       |                |             | 
+  query,evaluated_nodes,plan_nodes,nexecs
+FROM pg_track_optimizer() WHERE query LIKE '%FROM verify_test%';
+                               query                                | evaluated_nodes | plan_nodes | nexecs 
+--------------------------------------------------------------------+-----------------+------------+--------
+ EXPLAIN (COSTS OFF, ANALYZE, BUFFERS OFF, TIMING OFF, SUMMARY OFF)+|               2 |          2 |      1
+ SELECT val FROM verify_test;                                       |                 |            | 
 (1 row)
 
 DROP EXTENSION pg_track_optimizer;

--- a/expected/pg_track_optimizer_1.out
+++ b/expected/pg_track_optimizer_1.out
@@ -22,13 +22,13 @@ EXPLAIN (COSTS OFF) SELECT * FROM pto_test WHERE x < 1;
    Filter: (x < 1)
 (2 rows)
 
-SELECT querytext,avg_error>=0,nodes_assessed,nodes_total,exec_time>0,nexecs
+SELECT query,avg_error>=0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
 FROM pg_track_optimizer()
-ORDER BY querytext COLLATE "C"; -- Nothing to track for plain explain.
-                 querytext                 | ?column? | nodes_assessed | nodes_total | ?column? | nexecs 
--------------------------------------------+----------+----------------+-------------+----------+--------
- SELECT * FROM pg_track_optimizer_flush(); | t        |              1 |           1 | t        |      1
- SELECT * FROM pg_track_optimizer_reset(); | t        |              1 |           1 | t        |      1
+ORDER BY query COLLATE "C"; -- Nothing to track for plain explain.
+                   query                   | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
+-------------------------------------------+----------+-----------------+------------+----------+--------
+ SELECT * FROM pg_track_optimizer_flush(); | t        |               1 |          1 | t        |      1
+ SELECT * FROM pg_track_optimizer_reset(); | t        |               1 |          1 | t        |      1
 (2 rows)
 
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
@@ -39,18 +39,18 @@ SELECT * FROM pto_test WHERE x < 1;
    Filter: (x < 1)
 (2 rows)
 
-SELECT querytext,avg_error>=0,nodes_assessed,nodes_total,exec_time>0,nexecs
+SELECT query,avg_error>=0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
 FROM pg_track_optimizer()
-ORDER BY querytext; -- Must see it.
-                                  querytext                                  | ?column? | nodes_assessed | nodes_total | ?column? | nexecs 
------------------------------------------------------------------------------+----------+----------------+-------------+----------+--------
- EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)                      +| t        |              1 |           1 | t        |      1
- SELECT * FROM pto_test WHERE x < 1;                                         |          |                |             |          | 
- SELECT * FROM pg_track_optimizer_flush();                                   | t        |              1 |           1 | t        |      1
- SELECT * FROM pg_track_optimizer_reset();                                   | t        |              1 |           1 | t        |      1
- SELECT querytext,avg_error>=0,nodes_assessed,nodes_total,exec_time>0,nexecs+| t        |              2 |           2 | t        |      1
- FROM pg_track_optimizer()                                                  +|          |                |             |          | 
- ORDER BY querytext COLLATE "C";                                             |          |                |             |          | 
+ORDER BY query; -- Must see it.
+                                  query                                  | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
+-------------------------------------------------------------------------+----------+-----------------+------------+----------+--------
+ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)                  +| t        |               1 |          1 | t        |      1
+ SELECT * FROM pto_test WHERE x < 1;                                     |          |                 |            |          | 
+ SELECT * FROM pg_track_optimizer_flush();                               | t        |               1 |          1 | t        |      1
+ SELECT * FROM pg_track_optimizer_reset();                               | t        |               1 |          1 | t        |      1
+ SELECT query,avg_error>=0,evaluated_nodes,plan_nodes,exec_time>0,nexecs+| t        |               2 |          2 | t        |      1
+ FROM pg_track_optimizer()                                              +|          |                 |            |          | 
+ ORDER BY query COLLATE "C";                                             |          |                 |            |          | 
 (4 rows)
 
 -- TODO: Disable storing of queries, involving the extension UI objects
@@ -60,21 +60,21 @@ SELECT * FROM pto_test WHERE x < 1;
 (0 rows)
 
 -- Must see second execution of the query in nexecs (don't mind EXPLAIN)
-SELECT querytext,avg_error>=0,nodes_assessed,nodes_total,exec_time>0,nexecs
+SELECT query,avg_error>=0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
 FROM pg_track_optimizer()
-ORDER BY querytext;
-                                  querytext                                  | ?column? | nodes_assessed | nodes_total | ?column? | nexecs 
------------------------------------------------------------------------------+----------+----------------+-------------+----------+--------
- EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)                      +| t        |              1 |           1 | t        |      2
- SELECT * FROM pto_test WHERE x < 1;                                         |          |                |             |          | 
- SELECT * FROM pg_track_optimizer_flush();                                   | t        |              1 |           1 | t        |      1
- SELECT * FROM pg_track_optimizer_reset();                                   | t        |              1 |           1 | t        |      1
- SELECT querytext,avg_error>=0,nodes_assessed,nodes_total,exec_time>0,nexecs+| t        |              2 |           2 | t        |      1
- FROM pg_track_optimizer()                                                  +|          |                |             |          | 
- ORDER BY querytext COLLATE "C";                                             |          |                |             |          | 
- SELECT querytext,avg_error>=0,nodes_assessed,nodes_total,exec_time>0,nexecs+| t        |              2 |           2 | t        |      1
- FROM pg_track_optimizer()                                                  +|          |                |             |          | 
- ORDER BY querytext;                                                         |          |                |             |          | 
+ORDER BY query;
+                                  query                                  | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
+-------------------------------------------------------------------------+----------+-----------------+------------+----------+--------
+ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)                  +| t        |               1 |          1 | t        |      2
+ SELECT * FROM pto_test WHERE x < 1;                                     |          |                 |            |          | 
+ SELECT * FROM pg_track_optimizer_flush();                               | t        |               1 |          1 | t        |      1
+ SELECT * FROM pg_track_optimizer_reset();                               | t        |               1 |          1 | t        |      1
+ SELECT query,avg_error>=0,evaluated_nodes,plan_nodes,exec_time>0,nexecs+| t        |               2 |          2 | t        |      1
+ FROM pg_track_optimizer()                                              +|          |                 |            |          | 
+ ORDER BY query COLLATE "C";                                             |          |                 |            |          | 
+ SELECT query,avg_error>=0,evaluated_nodes,plan_nodes,exec_time>0,nexecs+| t        |               2 |          2 | t        |      1
+ FROM pg_track_optimizer()                                              +|          |                 |            |          | 
+ ORDER BY query;                                                         |          |                 |            |          | 
 (5 rows)
 
 /*
@@ -100,12 +100,12 @@ SELECT * FROM t1;
    ->  Parallel Seq Scan on t1 (actual rows=20000 loops=5)
 (4 rows)
 
-SELECT querytext,avg_error,rms_error,nodes_assessed,nodes_total,nexecs
-FROM pg_track_optimizer() WHERE querytext LIKE '%FROM t1%';
-                             querytext                              | avg_error | rms_error | nodes_assessed | nodes_total | nexecs 
---------------------------------------------------------------------+-----------+-----------+----------------+-------------+--------
- EXPLAIN (COSTS OFF, ANALYZE, BUFFERS OFF, TIMING OFF, SUMMARY OFF)+|         0 |         0 |              2 |           2 |      1
- SELECT * FROM t1;                                                  |           |           |                |             | 
+SELECT query,avg_error,rms_error,evaluated_nodes,plan_nodes,nexecs
+FROM pg_track_optimizer() WHERE query LIKE '%FROM t1%';
+                               query                                | avg_error | rms_error | evaluated_nodes | plan_nodes | nexecs 
+--------------------------------------------------------------------+-----------+-----------+-----------------+------------+--------
+ EXPLAIN (COSTS OFF, ANALYZE, BUFFERS OFF, TIMING OFF, SUMMARY OFF)+|         0 |         0 |               2 |          2 |      1
+ SELECT * FROM t1;                                                  |           |           |                 |            | 
 (1 row)
 
 /*
@@ -142,12 +142,12 @@ SELECT val FROM verify_test;
 -- a more understandable manner.
 -- So, make this test helpful in the future ...
 SELECT
-  querytext,nodes_assessed,nodes_total,nexecs
-FROM pg_track_optimizer() WHERE querytext LIKE '%FROM verify_test%';
-                             querytext                              | nodes_assessed | nodes_total | nexecs 
---------------------------------------------------------------------+----------------+-------------+--------
- EXPLAIN (COSTS OFF, ANALYZE, BUFFERS OFF, TIMING OFF, SUMMARY OFF)+|              2 |           2 |      1
- SELECT val FROM verify_test;                                       |                |             | 
+  query,evaluated_nodes,plan_nodes,nexecs
+FROM pg_track_optimizer() WHERE query LIKE '%FROM verify_test%';
+                               query                                | evaluated_nodes | plan_nodes | nexecs 
+--------------------------------------------------------------------+-----------------+------------+--------
+ EXPLAIN (COSTS OFF, ANALYZE, BUFFERS OFF, TIMING OFF, SUMMARY OFF)+|               2 |          2 |      1
+ SELECT val FROM verify_test;                                       |                 |            | 
 (1 row)
 
 DROP EXTENSION pg_track_optimizer;

--- a/pg_track_optimizer--0.1.sql
+++ b/pg_track_optimizer--0.1.sql
@@ -5,13 +5,13 @@
 CREATE FUNCTION pg_track_optimizer(
 	OUT dboid			Oid,
 	OUT queryid			bigint,
-	OUT querytext       text,
+	OUT query           text,
 	OUT avg_error		float8,
 	OUT rms_error		float8,
 	OUT twa_error		float8,
 	OUT wca_error		float8,
-	OUT nodes_assessed  integer,
-	OUT nodes_total     integer,
+	OUT evaluated_nodes integer,
+	OUT plan_nodes      integer,
 	OUT exec_time       float8,
 	OUT nexecs          bigint
 )

--- a/sql/join_filtering.sql
+++ b/sql/join_filtering.sql
@@ -45,15 +45,15 @@ JOIN join_inner ON join_outer.id = join_inner.id
 WHERE join_outer.val + join_inner.val > 5;
 
 -- Check that we tracked the query
--- The nodes_assessed should include the join node with filtered tuples
+-- The evaluated_nodes should include the join node with filtered tuples
 SELECT
-  querytext,
+  query,
   ROUND(avg_error::numeric,1) AS error,
-  nodes_assessed,
-  nodes_total,
+  evaluated_nodes,
+  plan_nodes,
   nexecs
 FROM pg_track_optimizer()
-WHERE querytext LIKE '%FROM join_outer%';
+WHERE query LIKE '%FROM join_outer%';
 
 -- Cleanup
 RESET enable_hashjoin;

--- a/sql/pg_track_optimizer.sql
+++ b/sql/pg_track_optimizer.sql
@@ -10,22 +10,22 @@ CREATE TABLE pto_test(x integer, y integer, z integer);
 ANALYZE pto_test;
 
 EXPLAIN (COSTS OFF) SELECT * FROM pto_test WHERE x < 1;
-SELECT querytext,avg_error>=0,nodes_assessed,nodes_total,exec_time>0,nexecs
+SELECT query,avg_error>=0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
 FROM pg_track_optimizer()
-ORDER BY querytext COLLATE "C"; -- Nothing to track for plain explain.
+ORDER BY query COLLATE "C"; -- Nothing to track for plain explain.
 
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT * FROM pto_test WHERE x < 1;
-SELECT querytext,avg_error>=0,nodes_assessed,nodes_total,exec_time>0,nexecs
+SELECT query,avg_error>=0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
 FROM pg_track_optimizer()
-ORDER BY querytext; -- Must see it.
+ORDER BY query; -- Must see it.
 -- TODO: Disable storing of queries, involving the extension UI objects
 
 SELECT * FROM pto_test WHERE x < 1;
 -- Must see second execution of the query in nexecs (don't mind EXPLAIN)
-SELECT querytext,avg_error>=0,nodes_assessed,nodes_total,exec_time>0,nexecs
+SELECT query,avg_error>=0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
 FROM pg_track_optimizer()
-ORDER BY querytext;
+ORDER BY query;
 
 /*
  * Tests for parallel workers.
@@ -47,8 +47,8 @@ SET pg_track_optimizer.mode = 'forced';
 EXPLAIN (COSTS OFF, ANALYZE, BUFFERS OFF, TIMING OFF, SUMMARY OFF)
 SELECT * FROM t1;
 
-SELECT querytext,avg_error,rms_error,nodes_assessed,nodes_total,nexecs
-FROM pg_track_optimizer() WHERE querytext LIKE '%FROM t1%';
+SELECT query,avg_error,rms_error,evaluated_nodes,plan_nodes,nexecs
+FROM pg_track_optimizer() WHERE query LIKE '%FROM t1%';
 
 /*
  * IndexOnlyScan may fetch dead tuples and recheck their state in the heap.
@@ -80,7 +80,7 @@ SELECT val FROM verify_test;
 -- a more understandable manner.
 -- So, make this test helpful in the future ...
 SELECT
-  querytext,nodes_assessed,nodes_total,nexecs
-FROM pg_track_optimizer() WHERE querytext LIKE '%FROM verify_test%';
+  query,evaluated_nodes,plan_nodes,nexecs
+FROM pg_track_optimizer() WHERE query LIKE '%FROM verify_test%';
 
 DROP EXTENSION pg_track_optimizer;


### PR DESCRIPTION
Renamed extension parameters to be more concise and descriptive:
- querytext → query (simpler, more natural)
- nodes_assessed → evaluated_nodes (clearer meaning)
- nodes_total → plan_nodes (more descriptive of what it represents)

Updated:
- SQL function definition
- C structure fields (DSMOptimizerTrackerEntry)
- All references in pg_track_optimizer.c
- Test files (pg_track_optimizer.sql, join_filtering.sql)
- README documentation and examples