### PR TITLE
Fix jo-bench workflow: set :datadir psql variable

### DIFF
--- a/.github/workflows/jo-bench.yml
+++ b/.github/workflows/jo-bench.yml
@@ -135,7 +135,7 @@ jobs:
       run: |
         export PATH="$HOME/postgresql/inst/bin:$PATH"
         cd ~/jo-bench
-        psql -d jobench -f copy.sql
+        psql -d jobench -v datadir="$HOME/jo-bench" -f copy.sql
 
     - name: Analyse tables
       run: |
@@ -155,7 +155,7 @@ jobs:
         for query_file in *.sql; do
           if [ -f "$query_file" ]; then
             echo "Running: $query_file"
-            psql -d jobench -f "$query_file" > /dev/null 2>&1 || echo "Query $query_file failed"
+            psql -d jobench -v datadir="$HOME/jo-bench" -f "$query_file" > /dev/null 2>&1 || echo "Query $query_file failed"
           fi
         done
         echo "All queries executed."


### PR DESCRIPTION
The copy.sql and query files use the :datadir psql variable to locate CSV data files. This fix adds -v datadir="$HOME/jo-bench" to psql commands to properly set the variable.

This resolves errors like:
  LINE 1: SELECT imdb_copy(:datadir, 'aka_title', 1);