### PR TITLE
Improve wiki report: truncate queries and show intersection of top-10

### DIFF
--- a/.github/scripts/generate-wiki-page.sh
+++ b/.github/scripts/generate-wiki-page.sh
@@ -49,7 +49,7 @@ cat > "$WIKI_PAGE" <<EOF
 
 ## Top Queries by Error Metrics
 
-This table shows queries that appear in the top 10 for any error metric (avg_error, rms_error, twa_error, or wca_error).
+This table shows queries that appear in the top 10 for **all** error metrics (avg_error, rms_error, twa_error, and wca_error). These are the queries with consistently poor estimation across all criteria.
 
 \`\`\`
 ${BENCHMARK_RESULTS}
@@ -59,7 +59,7 @@ ${BENCHMARK_RESULTS}
 
 The results above include the following metrics for each query:
 - **queryid**: Internal PostgreSQL query identifier
-- **query**: The SQL query text (normalised, with literals replaced by placeholders)
+- **query**: The SQL query text (normalised, with literals replaced by placeholders; truncated to first 32 characters)
 - **avg_error**: Simple average of log-scale errors across plan nodes
 - **rms_error**: Root Mean Square error (emphasises large estimation errors)
 - **twa_error**: Time-Weighted Average error (highlights errors in slow nodes)
@@ -68,7 +68,7 @@ The results above include the following metrics for each query:
 - **blks_accessed**: Total blocks accessed (shared, local, and temporary blocks hit/read/written)
 - **nexecs**: Number of times the query was executed
 
-Queries are shown if they appear in the top 10 for at least one error metric.
+Only queries appearing in the top 10 of **every** error metric are shown, representing the most consistently problematic queries.
 
 ---
 

--- a/.github/workflows/jo-bench.yml
+++ b/.github/workflows/jo-bench.yml
@@ -214,21 +214,19 @@ jobs:
 
         # Execute the benchmark query and save to temp file
         psql -d jobench -c "
-          SELECT DISTINCT p.queryid, p.query, p.avg_error, p.rms_error,
+          SELECT p.queryid, LEFT(p.query, 32) as query, p.avg_error, p.rms_error,
                  p.twa_error, p.wca_error, p.exec_time, p.blks_accessed, p.nexecs
-          FROM pg_track_optimizer p
+          FROM pg_track_optimizer() p
           WHERE p.queryid IN (
-            SELECT queryid FROM (
-              (SELECT queryid FROM pg_track_optimizer ORDER BY avg_error DESC LIMIT 10)
-              UNION ALL
-              (SELECT queryid FROM pg_track_optimizer ORDER BY rms_error DESC LIMIT 10)
-              UNION ALL
-              (SELECT queryid FROM pg_track_optimizer ORDER BY twa_error DESC LIMIT 10)
-              UNION ALL
-              (SELECT queryid FROM pg_track_optimizer ORDER BY wca_error DESC LIMIT 10)
-            ) top_queries
+            SELECT queryid FROM pg_track_optimizer() ORDER BY avg_error DESC LIMIT 10
+            INTERSECT
+            SELECT queryid FROM pg_track_optimizer() ORDER BY rms_error DESC LIMIT 10
+            INTERSECT
+            SELECT queryid FROM pg_track_optimizer() ORDER BY twa_error DESC LIMIT 10
+            INTERSECT
+            SELECT queryid FROM pg_track_optimizer() ORDER BY wca_error DESC LIMIT 10
           )
-          ORDER BY p.queryid;
+          ORDER BY p.avg_error DESC;
         " > /tmp/benchmark_results.txt
 
         # Save script path and extension commit before changing directories


### PR DESCRIPTION
Modified JO-Bench wiki report generation to:

1. Truncate query text to first 32 characters for better readability
   - Changed from showing full query to LEFT(query, 32)

2. Show intersection instead of union of top-10 queries
   - Changed from UNION (any top-10) to INTERSECT (all top-10s)
   - Now displays only queries that appear in top 10 for ALL error metrics
   - These represent the most consistently problematic queries

Updated wiki page template to:
- Clarify that results show queries in top 10 of all metrics
- Document that query text is truncated to 32 characters
- Emphasize these are queries with consistently poor estimation across all criteria (avg_error, rms_error, twa_error, wca_error)