### PR TITLE
Fix SQL syntax error in wiki report query using CTEs

### DIFF
--- a/.github/workflows/jo-bench.yml
+++ b/.github/workflows/jo-bench.yml
@@ -214,18 +214,24 @@ jobs:
 
         # Execute the benchmark query and save to temp file
         psql -d jobench -c "
+          WITH
+            top_avg AS (SELECT queryid FROM pg_track_optimizer() ORDER BY avg_error DESC LIMIT 10),
+            top_rms AS (SELECT queryid FROM pg_track_optimizer() ORDER BY rms_error DESC LIMIT 10),
+            top_twa AS (SELECT queryid FROM pg_track_optimizer() ORDER BY twa_error DESC LIMIT 10),
+            top_wca AS (SELECT queryid FROM pg_track_optimizer() ORDER BY wca_error DESC LIMIT 10),
+            intersection AS (
+              SELECT queryid FROM top_avg
+              INTERSECT
+              SELECT queryid FROM top_rms
+              INTERSECT
+              SELECT queryid FROM top_twa
+              INTERSECT
+              SELECT queryid FROM top_wca
+            )
           SELECT p.queryid, LEFT(p.query, 32) as query, p.avg_error, p.rms_error,
                  p.twa_error, p.wca_error, p.exec_time, p.blks_accessed, p.nexecs
           FROM pg_track_optimizer() p
-          WHERE p.queryid IN (
-            SELECT queryid FROM pg_track_optimizer() ORDER BY avg_error DESC LIMIT 10
-            INTERSECT
-            SELECT queryid FROM pg_track_optimizer() ORDER BY rms_error DESC LIMIT 10
-            INTERSECT
-            SELECT queryid FROM pg_track_optimizer() ORDER BY twa_error DESC LIMIT 10
-            INTERSECT
-            SELECT queryid FROM pg_track_optimizer() ORDER BY wca_error DESC LIMIT 10
-          )
+          WHERE p.queryid IN (SELECT queryid FROM intersection)
           ORDER BY p.avg_error DESC;
         " > /tmp/benchmark_results.txt
 


### PR DESCRIPTION
Fixed the INTERSECT query that was failing with syntax error. The issue was that INTERSECT can't be used directly with subqueries containing ORDER BY and LIMIT clauses.

Solution:
- Use Common Table Expressions (CTEs) to first capture the top 10 queries for each error metric
- Then perform INTERSECT on the simple CTEs without ORDER BY
- Finally join back to get full query details

This maintains the original intent of showing only queries that appear in the top 10 of ALL error metrics while fixing the PostgreSQL syntax requirements.