### PR TITLE
Convert wca_error to cumulative RStats type

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,18 +142,18 @@ LIMIT 10;
 - **avg_error**: Simple average of log-scale errors across plan nodes
 - **rms_error**: Root Mean Square (RMS) error - emphasises large estimation errors
 - **twa_error**: Time-Weighted Average (TWA) error - highlights estimation errors in time-consuming nodes
-- **wca_error**: Cost-Weighted Average (WCA) error - highlights estimation errors in nodes the planner considered expensive
+- **wca_error**: Cost-Weighted Average (WCA) error per execution (rstats type). Tracks running statistics of WCA error values across query executions. The view exposes this as `wca_min`, `wca_max`, `wca_cnt`, `wca_avg`, and `wca_dev` columns. Use the `->` operator on the raw function output to access fields: `wca_error -> 'mean'`, `wca_error -> 'stddev'`, etc.
 - **evaluated_nodes**: Number of plan nodes analysed
 - **plan_nodes**: Total plan nodes (some may be skipped, e.g., never-executed branches)
 - **exec_time**: Total execution time across all executions (milliseconds). Divide by `nexecs` to get average per execution
 - **nexecs**: Number of times the query was executed
-- **blks_accessed**: Running statistics of blocks accessed per execution (rstats type). Tracks count, mean, variance, standard deviation, min, and max of total blocks (shared + local + temporary) accessed in each query execution. Use `->` operator to access fields: `blks_accessed -> 'mean'`, `blks_accessed -> 'stddev'`, etc.
+- **blks_accessed**: Running statistics of blocks accessed per execution (rstats type). The view exposes this as `blks_min`, `blks_max`, `blks_cnt`, `blks_avg`, and `blks_dev` columns. Use the `->` operator on the raw function output to access fields: `blks_accessed -> 'mean'`, `blks_accessed -> 'stddev'`, etc.
 
-> **Note**: The columns `evaluated_nodes`, `plan_nodes`, `exec_time`, `nexecs`, and `blks_accessed` provide query execution metrics similar to those found in `pg_stat_statements`. These are included directly in `pg_track_optimizer` for user convenience, providing additional criteria for query filtering and analysis without requiring installation of `pg_stat_statements` or other extensions that may introduce additional overhead.
+> **Note**: The columns `evaluated_nodes`, `plan_nodes`, `exec_time`, `nexecs`, `wca_error`, and `blks_accessed` provide query execution metrics similar to those found in `pg_stat_statements`. These are included directly in `pg_track_optimizer` for user convenience, providing additional criteria for query filtering and analysis without requiring installation of `pg_stat_statements` or other extensions that may introduce additional overhead.
 
 ### The rstats Type
 
-The `rstats` type is a custom PostgreSQL type for tracking running statistics using Welford's algorithm for numerical stability. It's used for the `blks_accessed` column to provide detailed statistics about block access patterns.
+The `rstats` type is a custom PostgreSQL type for tracking running statistics using Welford's algorithm for numerical stability. It's used for the `wca_error` and `blks_accessed` columns to provide detailed statistics about cost-weighted errors and block access patterns across multiple query executions.
 
 **Fields accessible via the `->` operator:**
 - `count`: Number of observations
@@ -165,16 +165,26 @@ The `rstats` type is a custom PostgreSQL type for tracking running statistics us
 
 **Example usage:**
 ```sql
--- Get average blocks accessed per execution for queries
+-- Get average blocks accessed and WCA error statistics per execution
 SELECT queryid,
+       wca_error -> 'mean' as avg_wca_error,
+       wca_error -> 'stddev' as stddev_wca_error,
        blks_accessed -> 'mean' as avg_blocks,
        blks_accessed -> 'stddev' as stddev_blocks
-FROM pg_track_optimizer
+FROM pg_track_optimizer()
 WHERE blks_accessed -> 'mean' > 1000
-ORDER BY blks_accessed -> 'mean' DESC;
+ORDER BY wca_error -> 'mean' DESC;
+
+-- Use the view to get pre-calculated statistics
+SELECT queryid, query,
+       wca_avg, wca_dev, wca_min, wca_max,
+       blks_avg, blks_dev
+FROM pg_track_optimizer
+WHERE wca_avg > 2.0
+ORDER BY wca_avg DESC;
 ```
 
-The rstats type maintains numerically stable incremental statistics, automatically updating mean, variance, min, and max as new values are accumulated. This provides richer statistical insight than simple totals or averages.
+The rstats type maintains numerically stable incremental statistics, automatically updating mean, variance, min, and max as new values are accumulated. This provides richer statistical insight than simple totals or averages, especially useful for understanding the variability in query performance and cardinality estimation across multiple executions.
 
 ### Managing Statistics
 

--- a/expected/interface.out
+++ b/expected/interface.out
@@ -1,27 +1,27 @@
 CREATE EXTENSION pg_track_optimizer;
 \d pg_track_optimizer
                   View "public.pg_track_optimizer"
-     Column      |       Type       | Collation | Nullable | Default
+     Column      |       Type       | Collation | Nullable | Default 
 -----------------+------------------+-----------+----------+---------
- queryid         | bigint           |           |          |
- query           | text             |           |          |
- avg_error       | double precision |           |          |
- rms_error       | double precision |           |          |
- twa_error       | double precision |           |          |
- wca_min         | double precision |           |          |
- wca_max         | double precision |           |          |
- wca_cnt         | double precision |           |          |
- wca_avg         | double precision |           |          |
- wca_dev         | double precision |           |          |
- evaluated_nodes | integer          |           |          |
- plan_nodes      | integer          |           |          |
- exec_time       | double precision |           |          |
- nexecs          | bigint           |           |          |
- blks_min        | double precision |           |          |
- blks_max        | double precision |           |          |
- blks_cnt        | double precision |           |          |
- blks_avg        | double precision |           |          |
+ queryid         | bigint           |           |          | 
+ query           | text             |           |          | 
+ avg_error       | double precision |           |          | 
+ rms_error       | double precision |           |          | 
+ twa_error       | double precision |           |          | 
+ wca_min         | double precision |           |          | 
+ wca_max         | double precision |           |          | 
+ wca_cnt         | double precision |           |          | 
+ wca_avg         | double precision |           |          | 
+ wca_dev         | double precision |           |          | 
+ blks_min        | double precision |           |          | 
+ blks_max        | double precision |           |          | 
+ blks_cnt        | double precision |           |          | 
+ blks_avg        | double precision |           |          | 
  blks_dev        | double precision |           |          | 
+ evaluated_nodes | integer          |           |          | 
+ plan_nodes      | integer          |           |          | 
+ exec_time       | double precision |           |          | 
+ nexecs          | bigint           |           |          | 
 
 \df pg_track_optimizer_flush
                                  List of functions

--- a/expected/interface.out
+++ b/expected/interface.out
@@ -1,22 +1,26 @@
 CREATE EXTENSION pg_track_optimizer;
 \d pg_track_optimizer
                   View "public.pg_track_optimizer"
-     Column      |       Type       | Collation | Nullable | Default 
+     Column      |       Type       | Collation | Nullable | Default
 -----------------+------------------+-----------+----------+---------
- queryid         | bigint           |           |          | 
- query           | text             |           |          | 
- avg_error       | double precision |           |          | 
- rms_error       | double precision |           |          | 
- twa_error       | double precision |           |          | 
- wca_error       | double precision |           |          | 
- evaluated_nodes | integer          |           |          | 
- plan_nodes      | integer          |           |          | 
- exec_time       | double precision |           |          | 
- nexecs          | bigint           |           |          | 
- blks_min        | double precision |           |          | 
- blks_max        | double precision |           |          | 
- blks_cnt        | double precision |           |          | 
- blks_avg        | double precision |           |          | 
+ queryid         | bigint           |           |          |
+ query           | text             |           |          |
+ avg_error       | double precision |           |          |
+ rms_error       | double precision |           |          |
+ twa_error       | double precision |           |          |
+ wca_min         | double precision |           |          |
+ wca_max         | double precision |           |          |
+ wca_cnt         | double precision |           |          |
+ wca_avg         | double precision |           |          |
+ wca_dev         | double precision |           |          |
+ evaluated_nodes | integer          |           |          |
+ plan_nodes      | integer          |           |          |
+ exec_time       | double precision |           |          |
+ nexecs          | bigint           |           |          |
+ blks_min        | double precision |           |          |
+ blks_max        | double precision |           |          |
+ blks_cnt        | double precision |           |          |
+ blks_avg        | double precision |           |          |
  blks_dev        | double precision |           |          | 
 
 \df pg_track_optimizer_flush

--- a/expected/rstats.out
+++ b/expected/rstats.out
@@ -19,6 +19,12 @@ SELECT (NULL::double precision)::rstats;
  
 (1 row)
 
+SELECT rstats(); -- Check empty state
+                   rstats                   
+--------------------------------------------
+ (count:0,mean:-1,min:-1,max:-1,variance:0)
+(1 row)
+
 SELECT q.s, q.s + 1.0, q.s + 2.0, q.s + NULL
   FROM (VALUES (1.0::rstats)) AS q(s);
                     s                    |                ?column?                 |                  ?column?                   | ?column? 

--- a/pg_track_optimizer--0.1.sql
+++ b/pg_track_optimizer--0.1.sql
@@ -118,7 +118,7 @@ CREATE FUNCTION pg_track_optimizer(
 	OUT avg_error		float8,
 	OUT rms_error		float8,
 	OUT twa_error		float8,
-	OUT wca_error		float8,
+	OUT wca_error		rstats,
 	OUT evaluated_nodes integer,
 	OUT plan_nodes      integer,
 	OUT exec_time       float8,
@@ -135,8 +135,11 @@ LANGUAGE C STRICT VOLATILE;
  */
 CREATE VIEW pg_track_optimizer AS SELECT
   t.queryid, t.query, t.avg_error, t.rms_error, t.twa_error,
-  t.wca_error, t.evaluated_nodes, t.plan_nodes, t.exec_time, t.nexecs,
-  t.blks_accessed -> 'min' AS blks_min,t.blks_accessed -> 'max' AS blks_max,
+  t.wca_error -> 'min' AS wca_min, t.wca_error -> 'max' AS wca_max,
+  t.wca_error -> 'count' AS wca_cnt,
+  t.wca_error -> 'mean' AS wca_avg, t.wca_error -> 'stddev' AS wca_dev,
+  t.evaluated_nodes, t.plan_nodes, t.exec_time, t.nexecs,
+  t.blks_accessed -> 'min' AS blks_min, t.blks_accessed -> 'max' AS blks_max,
   t.blks_accessed -> 'count' AS blks_cnt,
   t.blks_accessed -> 'mean' AS blks_avg, t.blks_accessed -> 'stddev' AS blks_dev
 FROM pg_track_optimizer() t, pg_database d

--- a/rstats.h
+++ b/rstats.h
@@ -18,18 +18,18 @@
  */
 typedef struct RStats
 {
-    int64       count;          /* number of values */
-    double      mean;           /* running mean */
-    double      m2;             /* sum of squared differences from mean (for variance) */
-    double      min;            /* minimum value */
-    double      max;            /* maximum value */
+	int64	count;	/* number of values */
+	double	mean;	/* running mean */
+	double	m2;		/* sum of squared differences from mean (for variance) */
+	double	min;	/* minimum value */
+	double	max;	/* maximum value */
 } RStats;
 
 /* Macros for easier access */
-#define DatumGetRStatsP(X)      ((RStats *) DatumGetPointer(X))
-#define RStatsPGetDatum(X)      PointerGetDatum(X)
-#define PG_GETARG_RSTATS_P(n)   DatumGetRStatsP(PG_GETARG_DATUM(n))
-#define PG_RETURN_RSTATS_P(x)   return RStatsPGetDatum(x)
+#define DatumGetRStatsP(X) ((RStats *) DatumGetPointer(X))
+#define RStatsPGetDatum(X) PointerGetDatum(X)
+#define PG_GETARG_RSTATS_P(n) DatumGetRStatsP(PG_GETARG_DATUM(n))
+#define PG_RETURN_RSTATS_P(x) return RStatsPGetDatum(x)
 
 /*
  * Internal functions for manipulating RStats objects
@@ -41,5 +41,8 @@ extern void rstats_init_internal(RStats *result, double value);
 
 /* Add a value to existing statistics using Welford's algorithm */
 extern void rstats_add_value(RStats *stats, double value);
+
+extern bool rstats_is_empty(RStats *result);
+extern void rstats_set_empty(RStats *result);
 
 #endif /* RSTATS_H */

--- a/sql/rstats.sql
+++ b/sql/rstats.sql
@@ -5,6 +5,7 @@ CREATE EXTENSION pg_track_optimizer;
 SELECT 42.5::rstats;
 SELECT (42.1::double precision)::rstats;
 SELECT (NULL::double precision)::rstats;
+SELECT rstats(); -- Check empty state
 
 SELECT q.s, q.s + 1.0, q.s + 2.0, q.s + NULL
   FROM (VALUES (1.0::rstats)) AS q(s);


### PR DESCRIPTION
Changed wca_error from a simple double to an RStats type to track running statistics of Cost-Weighted Average error across multiple query executions, following the same pattern as blks_accessed.

Changes:
- DSMOptimizerTrackerEntry: wca_error field changed from double to RStats
- Initialization: Use rstats_init_internal() for new entries
- Accumulation: Use rstats_add_value() for existing entries
- SQL schema: wca_error output parameter changed from float8 to rstats
- View definition: Expanded wca_error into wca_min, wca_max, wca_cnt, wca_avg, and wca_dev columns using the -> operator
- Disk storage: Updated flush/restore logic to use memcpy for RStats
- EOFEntry: Updated initialisation to use RStats struct syntax

Updated documentation:
- README: Explained wca_error as rstats type with field access examples
- Added wca_error usage examples alongside blks_accessed
- Updated column descriptions to reflect new view columns
- Updated expected test output to show new wca_* columns

This provides richer statistical insight into WCA error variability across executions, enabling better analysis of query performance patterns and planner accuracy over time.