### PR TITLE
Convert exec_time from float8 to RStats cumulative type

### DIFF
--- a/.github/scripts/generate-wiki-page.sh
+++ b/.github/scripts/generate-wiki-page.sh
@@ -64,7 +64,7 @@ The results above include the following metrics for each query:
 - **rms_avg, rms_min, rms_max, rms_cnt, rms_dev**: Root Mean Square error statistics (emphasises large estimation errors)
 - **twa_avg, twa_min, twa_max, twa_cnt, twa_dev**: Time-Weighted Average error statistics (highlights errors in slow nodes)
 - **wca_avg, wca_min, wca_max, wca_cnt, wca_dev**: Cost-Weighted Average error statistics (highlights errors in expensive nodes)
-- **exec_time**: Total execution time across all executions (milliseconds)
+- **time_avg, time_min, time_max, time_cnt, time_dev**: Execution time statistics per query (milliseconds)
 - **blks_avg, blks_min, blks_max, blks_cnt, blks_dev**: Block access statistics across all executions
 - **nexecs**: Number of times the query was executed
 

--- a/.github/workflows/jo-bench.yml
+++ b/.github/workflows/jo-bench.yml
@@ -183,7 +183,7 @@ jobs:
             ROUND(AVG(wca_avg)::numeric, 2) as wca_error_mean,
             SUM(blks_avg) as total_blks_avg,
             SUM(nexecs) as total_executions,
-            ROUND(SUM(exec_time)::numeric, 2) as total_exec_time_ms
+            ROUND(SUM(time_avg * nexecs)::numeric, 2) as total_exec_time_ms
           FROM pg_track_optimizer;
         "
 
@@ -198,8 +198,8 @@ jobs:
             twa_avg,twa_min,twa_max,twa_cnt,twa_dev,
             wca_avg,wca_min,wca_max,wca_cnt,wca_dev,
             blks_avg,blks_min,blks_max,blks_cnt,blks_dev,
+            time_avg,time_min,time_max,time_cnt,time_dev,
             evaluated_nodes, plan_nodes,
-            ROUND(exec_time::numeric, 2) as exec_time_ms,
             nexecs
           FROM pg_track_optimizer
           ORDER BY avg_avg DESC
@@ -233,7 +233,8 @@ jobs:
                  v.rms_avg, v.rms_min, v.rms_max, v.rms_cnt, v.rms_dev,
                  v.twa_avg, v.twa_min, v.twa_max, v.twa_cnt, v.twa_dev,
                  v.wca_avg, v.wca_min, v.wca_max, v.wca_cnt, v.wca_dev,
-                 v.exec_time, v.blks_avg, v.blks_min, v.blks_max, v.blks_cnt, v.blks_dev, v.nexecs
+                 v.time_avg, v.time_min, v.time_max, v.time_cnt, v.time_dev,
+                 v.blks_avg, v.blks_min, v.blks_max, v.blks_cnt, v.blks_dev, v.nexecs
           FROM pg_track_optimizer v
           WHERE v.queryid IN (SELECT queryid FROM intersection)
           ORDER BY v.avg_avg DESC;

--- a/expected/interface.out
+++ b/expected/interface.out
@@ -25,18 +25,18 @@ CREATE EXTENSION pg_track_optimizer;
  wca_cnt         | double precision |           |          | 
  wca_avg         | double precision |           |          | 
  wca_dev         | double precision |           |          | 
- blks_min        | double precision |           |          |
- blks_max        | double precision |           |          |
- blks_cnt        | double precision |           |          |
- blks_avg        | double precision |           |          |
- blks_dev        | double precision |           |          |
- time_min        | double precision |           |          |
- time_max        | double precision |           |          |
- time_cnt        | double precision |           |          |
- time_avg        | double precision |           |          |
- time_dev        | double precision |           |          |
- evaluated_nodes | integer          |           |          |
- plan_nodes      | integer          |           |          |
+ blks_min        | double precision |           |          | 
+ blks_max        | double precision |           |          | 
+ blks_cnt        | double precision |           |          | 
+ blks_avg        | double precision |           |          | 
+ blks_dev        | double precision |           |          | 
+ time_min        | double precision |           |          | 
+ time_max        | double precision |           |          | 
+ time_cnt        | double precision |           |          | 
+ time_avg        | double precision |           |          | 
+ time_dev        | double precision |           |          | 
+ evaluated_nodes | integer          |           |          | 
+ plan_nodes      | integer          |           |          | 
  nexecs          | bigint           |           |          | 
 
 \df pg_track_optimizer_flush

--- a/expected/interface.out
+++ b/expected/interface.out
@@ -25,14 +25,18 @@ CREATE EXTENSION pg_track_optimizer;
  wca_cnt         | double precision |           |          | 
  wca_avg         | double precision |           |          | 
  wca_dev         | double precision |           |          | 
- blks_min        | double precision |           |          | 
- blks_max        | double precision |           |          | 
- blks_cnt        | double precision |           |          | 
- blks_avg        | double precision |           |          | 
- blks_dev        | double precision |           |          | 
- evaluated_nodes | integer          |           |          | 
- plan_nodes      | integer          |           |          | 
- exec_time       | double precision |           |          | 
+ blks_min        | double precision |           |          |
+ blks_max        | double precision |           |          |
+ blks_cnt        | double precision |           |          |
+ blks_avg        | double precision |           |          |
+ blks_dev        | double precision |           |          |
+ time_min        | double precision |           |          |
+ time_max        | double precision |           |          |
+ time_cnt        | double precision |           |          |
+ time_avg        | double precision |           |          |
+ time_dev        | double precision |           |          |
+ evaluated_nodes | integer          |           |          |
+ plan_nodes      | integer          |           |          |
  nexecs          | bigint           |           |          | 
 
 \df pg_track_optimizer_flush

--- a/expected/pg_track_optimizer.out
+++ b/expected/pg_track_optimizer.out
@@ -22,7 +22,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM pto_test WHERE x < 1;
    Filter: (x < 1)
 (2 rows)
 
-SELECT query, avg_error -> 'mean' >= 0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
+SELECT
+  query, avg_error -> 'mean' >= 0., evaluated_nodes, plan_nodes,
+  exec_time -> 'mean' > 0., nexecs
 FROM pg_track_optimizer()
 ORDER BY query COLLATE "C"; -- Nothing to track for plain explain.
                    query                   | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
@@ -39,18 +41,22 @@ SELECT * FROM pto_test WHERE x < 1;
    Filter: (x < 1)
 (2 rows)
 
-SELECT query, avg_error -> 'mean' >= 0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
+SELECT
+  query, avg_error -> 'mean' >= 0., evaluated_nodes, plan_nodes,
+  exec_time -> 'mean' > 0., nexecs
 FROM pg_track_optimizer()
 ORDER BY query; -- Must see it.
-                                        query                                         | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
---------------------------------------------------------------------------------------+----------+-----------------+------------+----------+--------
- EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)                               +| t        |               1 |          1 | t        |      1
- SELECT * FROM pto_test WHERE x < 1;                                                  |          |                 |            |          | 
- SELECT * FROM pg_track_optimizer_flush();                                            | t        |               1 |          1 | t        |      1
- SELECT * FROM pg_track_optimizer_reset();                                            | t        |               1 |          1 | t        |      1
- SELECT query, avg_error -> 'mean' >= 0,evaluated_nodes,plan_nodes,exec_time>0,nexecs+| t        |               2 |          2 | t        |      1
- FROM pg_track_optimizer()                                                           +|          |                 |            |          | 
- ORDER BY query COLLATE "C";                                                          |          |                 |            |          | 
+                              query                               | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
+------------------------------------------------------------------+----------+-----------------+------------+----------+--------
+ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)           +| t        |               1 |          1 | t        |      1
+ SELECT * FROM pto_test WHERE x < 1;                              |          |                 |            |          | 
+ SELECT                                                          +| t        |               2 |          2 | t        |      1
+   query, avg_error -> 'mean' >= 0., evaluated_nodes, plan_nodes,+|          |                 |            |          | 
+   exec_time -> 'mean' > 0., nexecs                              +|          |                 |            |          | 
+ FROM pg_track_optimizer()                                       +|          |                 |            |          | 
+ ORDER BY query COLLATE "C";                                      |          |                 |            |          | 
+ SELECT * FROM pg_track_optimizer_flush();                        | t        |               1 |          1 | t        |      1
+ SELECT * FROM pg_track_optimizer_reset();                        | t        |               1 |          1 | t        |      1
 (4 rows)
 
 -- TODO: Disable storing of queries, involving the extension UI objects
@@ -60,21 +66,27 @@ SELECT * FROM pto_test WHERE x < 1;
 (0 rows)
 
 -- Must see second execution of the query in nexecs (don't mind EXPLAIN)
-SELECT query, avg_error -> 'mean' >= 0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
+SELECT
+  query, avg_error -> 'mean' >= 0., evaluated_nodes, plan_nodes,
+  exec_time -> 'mean' > 0., nexecs
 FROM pg_track_optimizer()
 ORDER BY query;
-                                        query                                         | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
---------------------------------------------------------------------------------------+----------+-----------------+------------+----------+--------
- EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)                               +| t        |               1 |          1 | t        |      2
- SELECT * FROM pto_test WHERE x < 1;                                                  |          |                 |            |          | 
- SELECT * FROM pg_track_optimizer_flush();                                            | t        |               1 |          1 | t        |      1
- SELECT * FROM pg_track_optimizer_reset();                                            | t        |               1 |          1 | t        |      1
- SELECT query, avg_error -> 'mean' >= 0,evaluated_nodes,plan_nodes,exec_time>0,nexecs+| t        |               2 |          2 | t        |      1
- FROM pg_track_optimizer()                                                           +|          |                 |            |          | 
- ORDER BY query COLLATE "C";                                                          |          |                 |            |          | 
- SELECT query, avg_error -> 'mean' >= 0,evaluated_nodes,plan_nodes,exec_time>0,nexecs+| t        |               2 |          2 | t        |      1
- FROM pg_track_optimizer()                                                           +|          |                 |            |          | 
- ORDER BY query;                                                                      |          |                 |            |          | 
+                              query                               | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
+------------------------------------------------------------------+----------+-----------------+------------+----------+--------
+ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)           +| t        |               1 |          1 | t        |      2
+ SELECT * FROM pto_test WHERE x < 1;                              |          |                 |            |          | 
+ SELECT                                                          +| t        |               2 |          2 | t        |      1
+   query, avg_error -> 'mean' >= 0., evaluated_nodes, plan_nodes,+|          |                 |            |          | 
+   exec_time -> 'mean' > 0., nexecs                              +|          |                 |            |          | 
+ FROM pg_track_optimizer()                                       +|          |                 |            |          | 
+ ORDER BY query COLLATE "C";                                      |          |                 |            |          | 
+ SELECT                                                          +| t        |               2 |          2 | t        |      1
+   query, avg_error -> 'mean' >= 0., evaluated_nodes, plan_nodes,+|          |                 |            |          | 
+   exec_time -> 'mean' > 0., nexecs                              +|          |                 |            |          | 
+ FROM pg_track_optimizer()                                       +|          |                 |            |          | 
+ ORDER BY query;                                                  |          |                 |            |          | 
+ SELECT * FROM pg_track_optimizer_flush();                        | t        |               1 |          1 | t        |      1
+ SELECT * FROM pg_track_optimizer_reset();                        | t        |               1 |          1 | t        |      1
 (5 rows)
 
 /*

--- a/expected/pg_track_optimizer_1.out
+++ b/expected/pg_track_optimizer_1.out
@@ -22,7 +22,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM pto_test WHERE x < 1;
    Filter: (x < 1)
 (2 rows)
 
-SELECT query, avg_error -> 'mean' >= 0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
+SELECT
+  query, avg_error -> 'mean' >= 0., evaluated_nodes, plan_nodes,
+  exec_time -> 'mean' > 0., nexecs
 FROM pg_track_optimizer()
 ORDER BY query COLLATE "C"; -- Nothing to track for plain explain.
                    query                   | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
@@ -39,18 +41,22 @@ SELECT * FROM pto_test WHERE x < 1;
    Filter: (x < 1)
 (2 rows)
 
-SELECT query, avg_error -> 'mean' >= 0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
+SELECT
+  query, avg_error -> 'mean' >= 0., evaluated_nodes, plan_nodes,
+  exec_time -> 'mean' > 0., nexecs
 FROM pg_track_optimizer()
 ORDER BY query; -- Must see it.
-                                        query                                         | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
---------------------------------------------------------------------------------------+----------+-----------------+------------+----------+--------
- EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)                               +| t        |               1 |          1 | t        |      1
- SELECT * FROM pto_test WHERE x < 1;                                                  |          |                 |            |          | 
- SELECT * FROM pg_track_optimizer_flush();                                            | t        |               1 |          1 | t        |      1
- SELECT * FROM pg_track_optimizer_reset();                                            | t        |               1 |          1 | t        |      1
- SELECT query, avg_error -> 'mean' >= 0,evaluated_nodes,plan_nodes,exec_time>0,nexecs+| t        |               2 |          2 | t        |      1
- FROM pg_track_optimizer()                                                           +|          |                 |            |          | 
- ORDER BY query COLLATE "C";                                                          |          |                 |            |          | 
+                              query                               | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
+------------------------------------------------------------------+----------+-----------------+------------+----------+--------
+ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)           +| t        |               1 |          1 | t        |      1
+ SELECT * FROM pto_test WHERE x < 1;                              |          |                 |            |          | 
+ SELECT                                                          +| t        |               2 |          2 | t        |      1
+   query, avg_error -> 'mean' >= 0., evaluated_nodes, plan_nodes,+|          |                 |            |          | 
+   exec_time -> 'mean' > 0., nexecs                              +|          |                 |            |          | 
+ FROM pg_track_optimizer()                                       +|          |                 |            |          | 
+ ORDER BY query COLLATE "C";                                      |          |                 |            |          | 
+ SELECT * FROM pg_track_optimizer_flush();                        | t        |               1 |          1 | t        |      1
+ SELECT * FROM pg_track_optimizer_reset();                        | t        |               1 |          1 | t        |      1
 (4 rows)
 
 -- TODO: Disable storing of queries, involving the extension UI objects
@@ -60,21 +66,27 @@ SELECT * FROM pto_test WHERE x < 1;
 (0 rows)
 
 -- Must see second execution of the query in nexecs (don't mind EXPLAIN)
-SELECT query, avg_error -> 'mean' >= 0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
+SELECT
+  query, avg_error -> 'mean' >= 0., evaluated_nodes, plan_nodes,
+  exec_time -> 'mean' > 0., nexecs
 FROM pg_track_optimizer()
 ORDER BY query;
-                                        query                                         | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
---------------------------------------------------------------------------------------+----------+-----------------+------------+----------+--------
- EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)                               +| t        |               1 |          1 | t        |      2
- SELECT * FROM pto_test WHERE x < 1;                                                  |          |                 |            |          | 
- SELECT * FROM pg_track_optimizer_flush();                                            | t        |               1 |          1 | t        |      1
- SELECT * FROM pg_track_optimizer_reset();                                            | t        |               1 |          1 | t        |      1
- SELECT query, avg_error -> 'mean' >= 0,evaluated_nodes,plan_nodes,exec_time>0,nexecs+| t        |               2 |          2 | t        |      1
- FROM pg_track_optimizer()                                                           +|          |                 |            |          | 
- ORDER BY query COLLATE "C";                                                          |          |                 |            |          | 
- SELECT query, avg_error -> 'mean' >= 0,evaluated_nodes,plan_nodes,exec_time>0,nexecs+| t        |               2 |          2 | t        |      1
- FROM pg_track_optimizer()                                                           +|          |                 |            |          | 
- ORDER BY query;                                                                      |          |                 |            |          | 
+                              query                               | ?column? | evaluated_nodes | plan_nodes | ?column? | nexecs 
+------------------------------------------------------------------+----------+-----------------+------------+----------+--------
+ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)           +| t        |               1 |          1 | t        |      2
+ SELECT * FROM pto_test WHERE x < 1;                              |          |                 |            |          | 
+ SELECT                                                          +| t        |               2 |          2 | t        |      1
+   query, avg_error -> 'mean' >= 0., evaluated_nodes, plan_nodes,+|          |                 |            |          | 
+   exec_time -> 'mean' > 0., nexecs                              +|          |                 |            |          | 
+ FROM pg_track_optimizer()                                       +|          |                 |            |          | 
+ ORDER BY query COLLATE "C";                                      |          |                 |            |          | 
+ SELECT                                                          +| t        |               2 |          2 | t        |      1
+   query, avg_error -> 'mean' >= 0., evaluated_nodes, plan_nodes,+|          |                 |            |          | 
+   exec_time -> 'mean' > 0., nexecs                              +|          |                 |            |          | 
+ FROM pg_track_optimizer()                                       +|          |                 |            |          | 
+ ORDER BY query;                                                  |          |                 |            |          | 
+ SELECT * FROM pg_track_optimizer_flush();                        | t        |               1 |          1 | t        |      1
+ SELECT * FROM pg_track_optimizer_reset();                        | t        |               1 |          1 | t        |      1
 (5 rows)
 
 /*

--- a/pg_track_optimizer--0.1.sql
+++ b/pg_track_optimizer--0.1.sql
@@ -124,9 +124,9 @@ CREATE FUNCTION pg_track_optimizer(
 	OUT twa_error		rstats,
 	OUT wca_error		rstats,
 	OUT blks_accessed   rstats,
+	OUT exec_time       rstats,
 	OUT evaluated_nodes integer,
 	OUT plan_nodes      integer,
-	OUT exec_time       float8,
 	OUT nexecs          bigint
 )
 RETURNS setof record
@@ -165,7 +165,12 @@ CREATE VIEW pg_track_optimizer AS SELECT
   t.blks_accessed -> 'count' AS blks_cnt,
   t.blks_accessed -> 'mean' AS blks_avg, t.blks_accessed -> 'stddev' AS blks_dev,
 
-  t.evaluated_nodes, t.plan_nodes, t.exec_time, t.nexecs
+  /* Execution time statistics (milliseconds) */
+  t.exec_time -> 'min' AS time_min, t.exec_time -> 'max' AS time_max,
+  t.exec_time -> 'count' AS time_cnt,
+  t.exec_time -> 'mean' AS time_avg, t.exec_time -> 'stddev' AS time_dev,
+
+  t.evaluated_nodes, t.plan_nodes, t.nexecs
 FROM pg_track_optimizer() t, pg_database d
 WHERE t.dboid = d.oid AND datname = current_database();
 COMMENT ON VIEW pg_track_optimizer IS 'query tracking data for current database';

--- a/sql/pg_track_optimizer.sql
+++ b/sql/pg_track_optimizer.sql
@@ -10,20 +10,26 @@ CREATE TABLE pto_test(x integer, y integer, z integer);
 ANALYZE pto_test;
 
 EXPLAIN (COSTS OFF) SELECT * FROM pto_test WHERE x < 1;
-SELECT query, avg_error -> 'mean' >= 0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
+SELECT
+  query, avg_error -> 'mean' >= 0., evaluated_nodes, plan_nodes,
+  exec_time -> 'mean' > 0., nexecs
 FROM pg_track_optimizer()
 ORDER BY query COLLATE "C"; -- Nothing to track for plain explain.
 
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT * FROM pto_test WHERE x < 1;
-SELECT query, avg_error -> 'mean' >= 0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
+SELECT
+  query, avg_error -> 'mean' >= 0., evaluated_nodes, plan_nodes,
+  exec_time -> 'mean' > 0., nexecs
 FROM pg_track_optimizer()
 ORDER BY query; -- Must see it.
 -- TODO: Disable storing of queries, involving the extension UI objects
 
 SELECT * FROM pto_test WHERE x < 1;
 -- Must see second execution of the query in nexecs (don't mind EXPLAIN)
-SELECT query, avg_error -> 'mean' >= 0,evaluated_nodes,plan_nodes,exec_time>0,nexecs
+SELECT
+  query, avg_error -> 'mean' >= 0., evaluated_nodes, plan_nodes,
+  exec_time -> 'mean' > 0., nexecs
 FROM pg_track_optimizer()
 ORDER BY query;
 


### PR DESCRIPTION
This commit transforms exec_time from a simple cumulative total (float8) to an RStats type that tracks running statistics of execution times per query execution. This change provides richer statistical insights into query execution time patterns and variability.

Changes:

1. Core C code (pg_track_optimizer.c):
   - Updated DSMOptimizerTrackerEntry to use RStats type for exec_time
   - Modified comment to reflect it tracks "per query" statistics in milliseconds
   - Updated store_data() to initialize with rstats_set_empty() and accumulate using rstats_add_value() with seconds-to-milliseconds conversion
   - Changed pg_track_optimizer() output function to use RStatsPGetDatum()
   - Updated EOFEntry to initialize exec_time with RStats sentinel values
   - Modified _load_hash_table() to use memcpy for RStats structure restoration

2. SQL interface (pg_track_optimizer--0.1.sql):
   - Changed function signature from float8 to rstats type for exec_time
   - Reordered output parameters to group rstats types together
   - Expanded view definition to expose all RStats fields using -> operator:
     * time_min, time_max, time_cnt, time_avg, time_dev
   - Added comment clarifying milliseconds unit

3. Test expectations (expected/interface.out):
   - Added 5 new columns for exec_time statistics (time_*)
   - Removed single exec_time column
   - Updated total column count accordingly

4. Workflows (.github/workflows/jo-bench.yml):
   - Changed aggregate calculation from SUM(exec_time) to SUM(time_avg * nexecs) to properly compute total execution time from per-query averages
   - Updated top 10 query display to use expanded time_* fields
   - Modified benchmark results query to include all time_* statistics

5. Documentation updates:
   - README.md: * Converted Column Descriptions section to table format for better readability * Updated all examples to use time_* fields instead of exec_time scalar * Updated rstats type description to include exec_time * Modified workflow examples to use exec_time -> 'mean' accessor * Simplified example output table to focus on key metrics
   - generate-wiki-page.sh:
     * Updated column descriptions to reflect time_* expanded fields

Benefits of this change:
- Consistent design: All performance metrics (errors, blocks, time) now use RStats
- Execution time variability: Standard deviation reveals query performance consistency
- Per-execution insights: Min/max values help identify outliers and edge cases
- Better performance analysis: Mean execution time is more accurate than simple average when queries have variable workloads

This completes the migration of all major metrics to the RStats type, providing a uniform and powerful interface for tracking query performance statistics.