### PR TITLE
Add max_join_filtered statistic to track JOIN filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ LIMIT 10;
 | `blks_accessed` | rstats | Running statistics of blocks accessed per execution. |
 | `local_blks` | rstats | Running statistics of local blocks (read + written + dirtied) per execution. Local blocks indicate temporary tables or sorts spilling to disk, signaling insufficient work_mem. |
 | `exec_time` | rstats | Execution time per query in milliseconds. Tracks running statistics of execution times across query executions. |
+| `max_join_filtered` | rstats | Maximum filtered rows (nfiltered1 + nfiltered2) across all JOIN nodes per execution. Tracks running statistics across executions. High values indicate JOINs that filter many tuples, suggesting potential for optimization with parameterized NestLoop or missing indexes. |
 | `evaluated_nodes` | integer | Number of plan nodes analysed |
 | `plan_nodes` | integer | Total plan nodes (some may be skipped, e.g., never-executed branches) |
 | `nexecs` | bigint | Number of times the query was executed |

--- a/expected/interface.out
+++ b/expected/interface.out
@@ -40,6 +40,11 @@ CREATE EXTENSION pg_track_optimizer;
  time_cnt        | double precision |           |          | 
  time_avg        | double precision |           |          | 
  time_dev        | double precision |           |          | 
+ jf_min          | double precision |           |          | 
+ jf_max          | double precision |           |          | 
+ jf_cnt          | double precision |           |          | 
+ jf_avg          | double precision |           |          | 
+ jf_dev          | double precision |           |          | 
  evaluated_nodes | integer          |           |          | 
  plan_nodes      | integer          |           |          | 
  nexecs          | bigint           |           |          | 

--- a/pg_track_optimizer--0.1.sql
+++ b/pg_track_optimizer--0.1.sql
@@ -168,6 +168,7 @@ CREATE FUNCTION pg_track_optimizer(
 	OUT blks_accessed   rstats,
 	OUT local_blks      rstats,
 	OUT exec_time       rstats,
+	OUT max_join_filtered rstats,
 	OUT evaluated_nodes integer,
 	OUT plan_nodes      integer,
 	OUT nexecs          bigint
@@ -217,6 +218,11 @@ CREATE VIEW pg_track_optimizer AS SELECT
   t.exec_time -> 'min' AS time_min, t.exec_time -> 'max' AS time_max,
   t.exec_time -> 'count' AS time_cnt,
   t.exec_time -> 'mean' AS time_avg, t.exec_time -> 'stddev' AS time_dev,
+
+  /* Maximum JOIN filtered rows statistics */
+  t.max_join_filtered -> 'min' AS jf_min, t.max_join_filtered -> 'max' AS jf_max,
+  t.max_join_filtered -> 'count' AS jf_cnt,
+  t.max_join_filtered -> 'mean' AS jf_avg, t.max_join_filtered -> 'stddev' AS jf_dev,
 
   t.evaluated_nodes, t.plan_nodes, t.nexecs
 FROM pg_track_optimizer() t, pg_database d

--- a/plan_error.h
+++ b/plan_error.h
@@ -48,6 +48,9 @@ typedef struct PlanEstimatorContext
 	/* Buffer usage statistics for this query execution */
 	int64	blks_accessed;	/* Sum of all block hits, reads, and writes */
 	int64	local_blks;		/* Local blocks (read + written + dirtied) - indicates work_mem issues */
+
+	/* JOIN filtering statistics */
+	int64	max_join_filtered;	/* Maximum filtered rows (nfiltered1+nfiltered2) across all JOIN nodes */
 } PlanEstimatorContext;
 
 extern double plan_error(QueryDesc *queryDesc, PlanEstimatorContext *ctx);


### PR DESCRIPTION
Implement tracking of maximum filtered rows (nfiltered1 + nfiltered2) across all JOIN nodes in query plans. This metric helps identify queries with inefficient join strategies or missing indexes where JOINs filter many rows.

Changes:

1. plan_error.h:
   - Add max_join_filtered field to PlanEstimatorContext
   - Stores maximum filtered rows across all JOINs in execution

2. plan_error.c:
   - Initialize max_join_filtered to 0 in plan_error()
   - Compute max(nfiltered1 + nfiltered2) for JOIN nodes in prediction_walker()
   - Detects NestLoop, HashJoin, and MergeJoin nodes
   - Tracks maximum across all JOIN operations in query

3. pg_track_optimizer.c:
   - Add max_join_filtered RStats field to DSMOptimizerTrackerEntry
   - Initialize with rstats_set_empty() for new entries
   - Store values with rstats_add_value() in store_data()
   - Serialize with memcpy in flush/load operations
   - Update DATATBL_NCOLS from 13 to 14
   - Return max_join_filtered in pg_track_optimizer() C function

4. pg_track_optimizer--0.1.sql:
   - Add max_join_filtered rstats output parameter to pg_track_optimizer()
   - Add max_join_filtered statistics to pg_track_optimizer view:
     * join_filt_min, join_filt_max - min/max across executions
     * join_filt_cnt - execution count * join_filt_avg, join_filt_dev - mean and standard deviation

Use cases:
- Identify queries where JOINs filter excessive rows
- Detect missing indexes on join conditions
- Find queries with suboptimal join order
- Highlight candidates for query rewriting or index creation

Example query:
  SELECT queryid, query, join_filt_max, join_filt_avg FROM pg_track_optimizer WHERE join_filt_max > 10000 ORDER BY join_filt_max DESC;

This identifies queries where at least one JOIN filtered >10,000 rows, indicating potential optimization opportunities.