### PR TITLE
Add max_leaf_filtered statistic to track leaf node filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ LIMIT 10;
 | `local_blks` | rstats | Running statistics of local blocks (read + written + dirtied) per execution. Local blocks indicate temporary tables or sorts spilling to disk, signaling insufficient work_mem. |
 | `exec_time` | rstats | Execution time per query in milliseconds. Tracks running statistics of execution times across query executions. |
 | `max_join_filtered` | rstats | Maximum filtered rows (nfiltered1 + nfiltered2) across all JOIN nodes per execution. Tracks running statistics across executions. High values indicate JOINs that filter many tuples, suggesting potential for optimization with parameterized NestLoop or missing indexes. |
+| `max_leaf_filtered` | rstats | Maximum nfiltered1 for leaf nodes (scan nodes) per execution. Tracks running statistics across executions. High values indicate many rows were fetched but filtered out at the scan level, suggesting potential for better indexes or more selective predicates. |
 | `evaluated_nodes` | integer | Number of plan nodes analysed |
 | `plan_nodes` | integer | Total plan nodes (some may be skipped, e.g., never-executed branches) |
 | `nexecs` | bigint | Number of times the query was executed |

--- a/pg_track_optimizer--0.1.sql
+++ b/pg_track_optimizer--0.1.sql
@@ -169,6 +169,7 @@ CREATE FUNCTION pg_track_optimizer(
 	OUT local_blks      rstats,
 	OUT exec_time       rstats,
 	OUT max_join_filtered rstats,
+	OUT max_leaf_filtered rstats,
 	OUT evaluated_nodes integer,
 	OUT plan_nodes      integer,
 	OUT nexecs          bigint
@@ -223,6 +224,11 @@ CREATE VIEW pg_track_optimizer AS SELECT
   t.max_join_filtered -> 'min' AS jf_min, t.max_join_filtered -> 'max' AS jf_max,
   t.max_join_filtered -> 'count' AS jf_cnt,
   t.max_join_filtered -> 'mean' AS jf_avg, t.max_join_filtered -> 'stddev' AS jf_dev,
+
+  /* Maximum leaf node filtered rows statistics */
+  t.max_leaf_filtered -> 'min' AS lf_min, t.max_leaf_filtered -> 'max' AS lf_max,
+  t.max_leaf_filtered -> 'count' AS lf_cnt,
+  t.max_leaf_filtered -> 'mean' AS lf_avg, t.max_leaf_filtered -> 'stddev' AS lf_dev,
 
   t.evaluated_nodes, t.plan_nodes, t.nexecs
 FROM pg_track_optimizer() t, pg_database d

--- a/plan_error.h
+++ b/plan_error.h
@@ -51,6 +51,9 @@ typedef struct PlanEstimatorContext
 
 	/* JOIN filtering statistics */
 	int64	max_join_filtered;	/* Maximum filtered rows (nfiltered1+nfiltered2) across all JOIN nodes */
+
+	/* Leaf node filtering statistics */
+	int64	max_leaf_filtered;	/* Maximum nfiltered1 for leaf nodes in the query plan */
 } PlanEstimatorContext;
 
 extern double plan_error(QueryDesc *queryDesc, PlanEstimatorContext *ctx);


### PR DESCRIPTION
Add new RStats parameter to track the maximum nfiltered1 for leaf nodes in the query plan. Leaf nodes are scan nodes that directly access data sources (SeqScan, IndexScan, etc.).

High nfiltered1 values at leaf nodes indicate many rows were fetched but filtered out by WHERE conditions, suggesting potential optimizations:
- Add or improve indexes to reduce rows fetched
- Use more selective predicates
- Consider covering indexes for index-only scans

The lf_* columns (lf_min, lf_max, lf_cnt, lf_avg, lf_dev) expose the running statistics for this metric across query executions.

Changes:
- Added max_leaf_filtered field to PlanEstimatorContext (plan_error.h)
- Implemented tracking logic for leaf nodes using tmp_counter == ctx->counter check to identify leaf nodes (plan_error.c)
- Added max_leaf_filtered RStats field to DSMOptimizerTrackerEntry
- Updated DATATBL_NCOLS from 14 to 15
- Added initialization, storage, and serialization support
- Updated SQL function signature and view with lf_* columns
- Documented the new parameter in README