### PR TITLE
Add two-pass JOB workflow with extra indexing comparison

### DIFF
--- a/.github/scripts/extra_indexes.sql
+++ b/.github/scripts/extra_indexes.sql
@@ -1,0 +1,26 @@
+-- Extra indexes for JO-Bench to reduce filtered tuples
+-- Source: https://github.com/danolivo/pg_track_optimizer/wiki/Extra-Indexing
+--
+-- These indexes are applied in the second pass of JO-Bench testing
+-- to measure the impact of indexing on cardinality estimation errors.
+
+CREATE INDEX aka_name_idx_1 ON aka_name (info);
+CREATE INDEX aka_name_idx_2 ON aka_name (name);
+CREATE INDEX aka_title_idx_1 ON aka_title (info,note);
+CREATE INDEX cast_info_idx_1 ON cast_info (note);
+CREATE INDEX company_name_idx_1 ON company_name (country_code);
+CREATE INDEX complete_cast_idx_1 ON complete_cast (info);
+CREATE INDEX complete_cast_idx_2 ON complete_cast (info,note);
+CREATE INDEX info_type_idx_1 ON info_type (info);
+CREATE INDEX keyword_idx_1 ON keyword (keyword);
+CREATE INDEX movie_companies_idx_1 ON movie_companies (country_code);
+CREATE INDEX movie_companies_idx_2 ON movie_companies (info);
+CREATE INDEX movie_companies_idx_3 ON movie_companies (info,note);
+CREATE INDEX movie_companies_idx_4 ON movie_companies (note);
+CREATE INDEX movie_info_idx_1 ON movie_info (info);
+CREATE INDEX movie_info_idx_idx_1 ON movie_info_idx (info);
+CREATE INDEX movie_keyword_idx_1 ON movie_keyword (info);
+CREATE INDEX movie_keyword_idx_2 ON movie_keyword (keyword);
+CREATE INDEX movie_keyword_idx_3 ON movie_keyword (note);
+CREATE INDEX movie_link_idx_1 ON movie_link (note);
+CREATE INDEX title_idx_1 ON title (production_year);

--- a/.github/scripts/generate-wiki-page.sh
+++ b/.github/scripts/generate-wiki-page.sh
@@ -83,10 +83,13 @@ cat > "$WIKI_PAGE" <<EOF
 - **PostgreSQL Version**: ${PG_VERSION}
 - **PostgreSQL Commit**: [\`${PG_COMMIT:0:7}\`](https://github.com/postgres/postgres/commit/${PG_COMMIT})
 - **Extension Commit**: [\`${EXT_COMMIT:0:7}\`](https://github.com/danolivo/pg_track_optimizer/commit/${EXT_COMMIT})
+- **Test Configuration**: Two-pass testing (Pass 1: no extra indexes, Pass 2: with [extra indexes](Extra-Indexing))
 
-## Top Queries by Error Metrics
+## Top Queries by Error Metrics (Pass 2 - with extra indexes)
 
 This table shows queries that appear in the top 10 for **all** error metrics (avg_avg, rms_avg, twa_avg, and wca_avg). These are the queries with consistently poor estimation across all criteria.
+
+**Note**: These results are from **Pass 2** (with extra indexes). Pass 1 results (without extra indexes) are available as a separate artifact for comparison.
 
 \`\`\`
 ${BENCHMARK_RESULTS}
@@ -112,7 +115,12 @@ Only queries appearing in the top 10 of **every** error metric are shown, repres
 
 ## How to Use Workflow Artifacts
 
-The workflow produces a CSV artifact (\`pg_track_optimizer_jobench_results\`) containing complete benchmark results for all queries. You can download this artifact from the workflow run and import it into your own PostgreSQL database for analysis.
+The workflow performs **two passes** and produces two CSV artifacts for comparison:
+
+- **Pass 1** (\`pg_track_optimizer_jobench_results_pass1\`): Results **without** extra indexes
+- **Pass 2** (\`pg_track_optimizer_jobench_results_pass2\`): Results **with** extra indexes from [Extra-Indexing](Extra-Indexing) wiki page
+
+The results shown below are from **Pass 2** (with extra indexes). Both artifacts can be downloaded from the workflow run and imported into your own PostgreSQL database for comparative analysis.
 
 ### 1. Create the tracking table
 

--- a/.github/workflows/jo-bench.yml
+++ b/.github/workflows/jo-bench.yml
@@ -149,11 +149,11 @@ jobs:
         export PATH="$HOME/postgresql/inst/bin:$PATH"
         psql -d jobench -c "SELECT pg_track_optimizer_reset();"
 
-    - name: Execute jo-bench queries
+    - name: Execute jo-bench queries (Pass 1 - without extra indexes)
       run: |
         export PATH="$HOME/postgresql/inst/bin:$PATH"
         cd ~/jo-bench/queries
-        echo "Executing queries..."
+        echo "Executing queries (Pass 1 - without extra indexes)..."
         for query_file in *.sql; do
           if [ -f "$query_file" ]; then
             echo "Running: $query_file"
@@ -163,18 +163,60 @@ jobs:
               echo "Query $query_file failed"
           fi
         done
-        echo "All queries executed."
+        echo "All queries executed (Pass 1)."
 
-    - name: Export pg_track_optimizer results to CSV
+    - name: Export pg_track_optimizer results to CSV (Pass 1)
       run: |
         export PATH="$HOME/postgresql/inst/bin:$PATH"
-        psql -d jobench -c "\COPY (SELECT * FROM pg_track_optimizer ORDER BY avg_avg DESC) TO '/tmp/pg_track_optimizer_results.csv' WITH CSV HEADER"
-        echo "Results exported to CSV:"
-        head -20 /tmp/pg_track_optimizer_results.csv
+        psql -d jobench -c "\COPY (SELECT * FROM pg_track_optimizer ORDER BY avg_avg DESC) TO '/tmp/pg_track_optimizer_results_pass1.csv' WITH CSV HEADER"
+        echo "Pass 1 results exported to CSV:"
+        head -20 /tmp/pg_track_optimizer_results_pass1.csv
 
-    - name: Show summary statistics
+    - name: Apply extra indexes
       run: |
         export PATH="$HOME/postgresql/inst/bin:$PATH"
+        echo "Applying extra indexes from wiki..."
+        psql -d jobench -f .github/scripts/extra_indexes.sql
+        echo "Extra indexes applied."
+
+    - name: Analyse tables after indexing
+      run: |
+        export PATH="$HOME/postgresql/inst/bin:$PATH"
+        psql -d jobench -c "VACUUM ANALYZE;"
+
+    - name: Reset pg_track_optimizer statistics (before Pass 2)
+      run: |
+        export PATH="$HOME/postgresql/inst/bin:$PATH"
+        psql -d jobench -c "SELECT pg_track_optimizer_reset();"
+        echo "Statistics reset for Pass 2."
+
+    - name: Execute jo-bench queries (Pass 2 - with extra indexes)
+      run: |
+        export PATH="$HOME/postgresql/inst/bin:$PATH"
+        cd ~/jo-bench/queries
+        echo "Executing queries (Pass 2 - with extra indexes)..."
+        for query_file in *.sql; do
+          if [ -f "$query_file" ]; then
+            echo "Running: $query_file"
+            # Add filename comment before query and execute
+            (echo "/* $query_file */"; cat "$query_file") | \
+              psql -d jobench -v datadir="'$HOME/jo-bench'" > /dev/null 2>&1 || \
+              echo "Query $query_file failed"
+          fi
+        done
+        echo "All queries executed (Pass 2)."
+
+    - name: Export pg_track_optimizer results to CSV (Pass 2)
+      run: |
+        export PATH="$HOME/postgresql/inst/bin:$PATH"
+        psql -d jobench -c "\COPY (SELECT * FROM pg_track_optimizer ORDER BY avg_avg DESC) TO '/tmp/pg_track_optimizer_results_pass2.csv' WITH CSV HEADER"
+        echo "Pass 2 results exported to CSV:"
+        head -20 /tmp/pg_track_optimizer_results_pass2.csv
+
+    - name: Show summary statistics (Pass 2 - with extra indexes)
+      run: |
+        export PATH="$HOME/postgresql/inst/bin:$PATH"
+        echo "=== Summary Statistics - Pass 2 (with extra indexes) ==="
         psql -d jobench -c "
           SELECT
             COUNT(*) as total_queries,
@@ -189,9 +231,10 @@ jobs:
           FROM pg_track_optimizer;
         "
 
-    - name: Show top 10 worst queries
+    - name: Show top 10 worst queries (Pass 2 - with extra indexes)
       run: |
         export PATH="$HOME/postgresql/inst/bin:$PATH"
+        echo "=== Top 10 Worst Queries - Pass 2 (with extra indexes) ==="
         psql -d jobench -c "
           SELECT
             LEFT(query, 80) as query_preview,
@@ -269,11 +312,18 @@ jobs:
         export PATH="$HOME/postgresql/inst/bin:$PATH"
         pg_ctl -D $HOME/pgdata stop || true
 
-    - name: Upload results CSV
+    - name: Upload Pass 1 results CSV (without extra indexes)
       uses: actions/upload-artifact@v4
       with:
-        name: pg_track_optimizer_jobench_results
-        path: /tmp/pg_track_optimizer_results.csv
+        name: pg_track_optimizer_jobench_results_pass1
+        path: /tmp/pg_track_optimizer_results_pass1.csv
+        retention-days: 7
+
+    - name: Upload Pass 2 results CSV (with extra indexes)
+      uses: actions/upload-artifact@v4
+      with:
+        name: pg_track_optimizer_jobench_results_pass2
+        path: /tmp/pg_track_optimizer_results_pass2.csv
         retention-days: 7
 
     - name: Upload PostgreSQL log


### PR DESCRIPTION
Implement a two-pass testing approach for JO-Bench workflow:

Pass 1: Run all queries WITHOUT extra indexes
- Execute all JOB queries on baseline schema with standard indexes
- Export results to pg_track_optimizer_results_pass1.csv
- Capture baseline cardinality estimation errors

Pass 2: Run all queries WITH extra indexes
- Apply 20 additional indexes targeting filtered columns
- Reset pg_track_optimizer statistics
- Re-execute all JOB queries with enhanced indexing
- Export results to pg_track_optimizer_results_pass2.csv
- Capture improved cardinality estimation metrics

Changes:
- Add .github/scripts/extra_indexes.sql with 20 indexes from wiki
- Modify jo-bench.yml workflow to execute two passes
- Update wiki page generation to indicate Pass 2 results
- Upload both Pass 1 and Pass 2 CSV artifacts for comparison
- Add VACUUM ANALYZE after index creation

This allows comparing cardinality estimation accuracy before and after applying targeted indexes to reduce filtered tuple counts.

Ref: https://github.com/danolivo/pg_track_optimizer/wiki/Extra-Indexing