### PR TITLE
Rename local_blks to temp_blks and fix buffer usage accounting

### DIFF
--- a/META.json
+++ b/META.json
@@ -2,15 +2,15 @@
 	"name": "pg_track_optimizer",
 	"abstract": "Track planning decisions in comparison with execution reality",
 	"description": "A lightweight PostgreSQL extension for detecting suboptimal query plans by analysing the gap between planner estimates and actual execution statistics.",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"maintainer": "Andrei Lepikhov <lepihov@gmail.com>",
 	"license": "mit",
 	"provides": {
 		"pg_track_optimizer": {
 			"abstract": "Track planning decisions in comparison with execution reality",
-			"file": "pg_track_optimizer--0.9.1.sql",
+			"file": "pg_track_optimizer--0.9.2.sql",
 			"docfile": "README.md",
-			"version": "0.9.1"
+			"version": "0.9.2"
 		}
 	},
 	"prereqs": {

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OBJS = \
 PGFILEDESC = "pg_track_optimizer - track planning decisions"
 
 EXTENSION = pg_track_optimizer
-EXTVERSION = 0.9.1
+EXTVERSION = 0.9.2
 
 DATA = pg_track_optimizer--$(EXTVERSION).sql
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ SELECT
     twa_avg, twa_min, twa_max,  -- twa_error expanded fields
     wca_avg, wca_min, wca_max,  -- wca_error expanded fields
     blks_avg, blks_min, blks_max,  -- blks_accessed expanded fields
-    local_avg, local_min, local_max,  -- local_blks expanded fields
+    temp_avg, temp_min, temp_max,  -- temp_blks expanded fields
     time_avg, time_min, time_max,  -- exec_time expanded fields
     evaluated_nodes,
     plan_nodes,
@@ -163,7 +163,7 @@ LIMIT 10;
 | `twa_error` | rstats | Time-Weighted Average (TWA) error per execution. Tracks running statistics of TWA error values across query executions. |
 | `wca_error` | rstats | Cost-Weighted Average (WCA) error per execution. Tracks running statistics of WCA error values across query executions. |
 | `blks_accessed` | rstats | Running statistics of blocks accessed per execution. |
-| `local_blks` | rstats | Running statistics of local blocks (read + written + dirtied) per execution. Local blocks indicate temporary tables or sorts spilling to disk, signaling insufficient work_mem. |
+| `temp_blks` | rstats | Running statistics of temp blocks (read + written) per execution. Temp blocks indicate sorts or hash joins spilling to disk, signaling insufficient work_mem. |
 | `exec_time` | rstats | Execution time per query in milliseconds. Tracks running statistics of execution times across query executions. |
 | `f_join_filter` | rstats | JOIN filtering factor - dimensionless time-weighted filtering overhead for JOIN nodes per execution. Calculated as (filtered_rows / produced_rows) × relative_time. Tracks running statistics across executions. Higher values indicate JOINs where excessive filtering significantly impacts query performance, suggesting potential for better join strategies, indexes, or query rewrites. |
 | `f_scan_filter` | rstats | Leaf node filtering factor - dimensionless time-weighted filtering overhead for scan nodes per execution. Calculated as (filtered_rows / produced_rows) × relative_time. Tracks running statistics across executions. Higher values indicate scans where many rows were fetched but filtered out, consuming significant query time - prime candidates for better indexes or predicate pushdown. |
@@ -173,11 +173,11 @@ LIMIT 10;
 | `plan_nodes` | integer | Total plan nodes (some may be skipped, e.g., never-executed branches) |
 | `nexecs` | bigint | Number of times the query was executed |
 
-> **Note**: The columns `evaluated_nodes`, `plan_nodes`, `exec_time`, `nexecs`, `blks_accessed`, and `local_blks` provide query execution metrics similar to those found in `pg_stat_statements`. These are included directly in `pg_track_optimizer` for user convenience, providing additional criteria for query filtering and analysis without requiring installation of `pg_stat_statements` or other extensions that may introduce additional overhead.
+> **Note**: The columns `evaluated_nodes`, `plan_nodes`, `exec_time`, `nexecs`, `blks_accessed`, and `temp_blks` provide query execution metrics similar to those found in `pg_stat_statements`. These are included directly in `pg_track_optimizer` for user convenience, providing additional criteria for query filtering and analysis without requiring installation of `pg_stat_statements` or other extensions that may introduce additional overhead.
 
 ### The RStats Type
 
-The `RStats` type is a custom PostgreSQL type for tracking running statistics using Welford's algorithm for numerical stability (thanks [pg_running_stats](https://github.com/chanukyasds/pg_running_stats) for the idea and coding template). It's used for the `avg_error`, `rms_error`, `twa_error`, `wca_error`, `blks_accessed`, `local_blks`, and `exec_time` columns to provide detailed statistics about all error metrics, block access patterns, local block usage (work_mem indicator), and execution times across multiple query executions.
+The `RStats` type is a custom PostgreSQL type for tracking running statistics using Welford's algorithm for numerical stability (thanks [pg_running_stats](https://github.com/chanukyasds/pg_running_stats) for the idea and coding template). It's used for the `avg_error`, `rms_error`, `twa_error`, `wca_error`, `blks_accessed`, `temp_blks`, and `exec_time` columns to provide detailed statistics about all error metrics, block access patterns, temp block usage (work_mem indicator), and execution times across multiple query executions.
 
 **Fields accessible via the `->` operator:**
 - `count`: Number of observations
@@ -268,8 +268,8 @@ Normalises estimation error over execution time. Allows comparing queries with v
 ### High `wca_avg` (cost-weighted average error)
 Normalises estimation error over cost. It should help compare the estimation errors of queries with very different structures.
 
-### High `local_avg` (local blocks)
-Indicates queries using local blocks, which signal work_mem issues rather than optimisation problems:
+### High `temp_avg` (temp blocks)
+Indicates queries using temp blocks, which signal work_mem issues rather than optimisation problems:
 - **Insufficient work_mem**: Sorts, hash joins, or aggregates spilling to disk
 - **Memory-intensive operations**: Queries with high memory requirements exceeding work_mem
 - **Quick fix**: Unlike optimisation errors, this can often be resolved by simply increasing work_mem

--- a/expected/interface.out
+++ b/expected/interface.out
@@ -43,11 +43,11 @@ FROM pg_track_optimizer_status;
  blks_cnt        | double precision |           |          | 
  blks_avg        | double precision |           |          | 
  blks_dev        | double precision |           |          | 
- local_min       | double precision |           |          | 
- local_max       | double precision |           |          | 
- local_cnt       | double precision |           |          | 
- local_avg       | double precision |           |          | 
- local_dev       | double precision |           |          | 
+ temp_min        | double precision |           |          | 
+ temp_max        | double precision |           |          | 
+ temp_cnt        | double precision |           |          | 
+ temp_avg        | double precision |           |          | 
+ temp_dev        | double precision |           |          | 
  time_min        | double precision |           |          | 
  time_max        | double precision |           |          | 
  time_cnt        | double precision |           |          | 

--- a/pg_track_optimizer--0.9.2.sql
+++ b/pg_track_optimizer--0.9.2.sql
@@ -217,7 +217,7 @@ CREATE FUNCTION pg_track_optimizer(
 	OUT twa_error		rstats,
 	OUT wca_error		rstats,
 	OUT blks_accessed   rstats,
-	OUT local_blks      rstats,
+	OUT temp_blks       rstats,
 	OUT exec_time       rstats,
 	OUT f_join_filter   rstats,
 	OUT f_scan_filter   rstats,
@@ -263,10 +263,10 @@ CREATE VIEW pg_track_optimizer AS SELECT
   t.blks_accessed -> 'count' AS blks_cnt,
   t.blks_accessed -> 'mean' AS blks_avg, t.blks_accessed -> 'stddev' AS blks_dev,
 
-  /* Local blocks statistics (work_mem indicator) */
-  t.local_blks -> 'min' AS local_min, t.local_blks -> 'max' AS local_max,
-  t.local_blks -> 'count' AS local_cnt,
-  t.local_blks -> 'mean' AS local_avg, t.local_blks -> 'stddev' AS local_dev,
+  /* Temp blocks statistics (work_mem indicator) */
+  t.temp_blks -> 'min' AS temp_min, t.temp_blks -> 'max' AS temp_max,
+  t.temp_blks -> 'count' AS temp_cnt,
+  t.temp_blks -> 'mean' AS temp_avg, t.temp_blks -> 'stddev' AS temp_dev,
 
   /* Execution time statistics (milliseconds) */
   t.exec_time -> 'min' AS time_min, t.exec_time -> 'max' AS time_max,

--- a/pg_track_optimizer.c
+++ b/pg_track_optimizer.c
@@ -45,7 +45,7 @@ PG_MODULE_MAGIC;
 #else
 PG_MODULE_MAGIC_EXT(
 					.name = "pg_track_optimizer",
-					.version = "0.9.1"
+					.version = "0.9.2"
 );
 #endif
 
@@ -107,7 +107,7 @@ typedef struct DSMOptimizerTrackerEntry
 	RStats					twa_error;			/* Time-weighted average error - running stats */
 	RStats					wca_error;			/* Weighted Cost Average error - running stats */
 	RStats					blks_accessed;		/* Block I/O (hits + reads + writes) - running stats */
-	RStats					local_blks;			/* Local blocks (read + written + dirtied) - work_mem indicator */
+	RStats					temp_blks;			/* Temp blocks (read + written) - work_mem indicator */
 	RStats					exec_time;			/* Execution time per query - running stats (milliseconds) */
 	RStats					f_join_filter;	/* Maximum filtered rows (nfiltered1+nfiltered2) across JOIN nodes */
 	RStats					f_scan_filter;	/* Maximum nfiltered1 for leaf nodes in the query plan */
@@ -420,7 +420,7 @@ store_data(QueryDesc *queryDesc, PlanEstimatorContext *ctx)
 		rstats_set_empty(&entry->twa_error);
 		rstats_set_empty(&entry->wca_error);
 		rstats_set_empty(&entry->blks_accessed);
-		rstats_set_empty(&entry->local_blks);
+		rstats_set_empty(&entry->temp_blks);
 		rstats_set_empty(&entry->exec_time);
 		rstats_set_empty(&entry->f_join_filter);
 		rstats_set_empty(&entry->f_scan_filter);
@@ -440,7 +440,7 @@ store_data(QueryDesc *queryDesc, PlanEstimatorContext *ctx)
 	 * accumulated when non-negative. Negative values can occur legitimately when
 	 * calculations produce undefined results (e.g., division by zero cost in wca_error).
 	 *
-	 * blks_accessed & local_blks: Always accumulated. Block access counts are
+	 * blks_accessed & temp_blks: Always accumulated. Block access counts are
 	 * always >= 0 and represent valid physical I/O measurements for every
 	 * execution.
 	 */
@@ -454,8 +454,8 @@ store_data(QueryDesc *queryDesc, PlanEstimatorContext *ctx)
 		rstats_add_value(&entry->wca_error, ctx->wca_error);
 	Assert(ctx->blks_accessed >= 0);
 	rstats_add_value(&entry->blks_accessed, (double) ctx->blks_accessed);
-	Assert(ctx->local_blks >= 0);
-	rstats_add_value(&entry->local_blks, (double) ctx->local_blks);
+	Assert(ctx->temp_blks >= 0);
+	rstats_add_value(&entry->temp_blks, (double) ctx->temp_blks);
 	Assert(ctx->f_join_filter >= 0.);
 	rstats_add_value(&entry->f_join_filter, ctx->f_join_filter);
 	Assert(ctx->f_scan_filter >= 0.);
@@ -724,7 +724,7 @@ pg_track_optimizer(PG_FUNCTION_ARGS)
 		values[i++] = RStatsPGetDatum(&entry->twa_error);
 		values[i++] = RStatsPGetDatum(&entry->wca_error);
 		values[i++] = RStatsPGetDatum(&entry->blks_accessed);
-		values[i++] = RStatsPGetDatum(&entry->local_blks);
+		values[i++] = RStatsPGetDatum(&entry->temp_blks);
 		values[i++] = RStatsPGetDatum(&entry->exec_time);
 		values[i++] = RStatsPGetDatum(&entry->f_join_filter);
 		values[i++] = RStatsPGetDatum(&entry->f_scan_filter);
@@ -1219,7 +1219,7 @@ _load_hash_table(TODSMRegistry *state)
 		memcpy(&entry->twa_error, &disk_entry.twa_error, sizeof(RStats));
 		memcpy(&entry->wca_error, &disk_entry.wca_error, sizeof(RStats));
 		memcpy(&entry->blks_accessed, &disk_entry.blks_accessed, sizeof(RStats));
-		memcpy(&entry->local_blks, &disk_entry.local_blks, sizeof(RStats));
+		memcpy(&entry->temp_blks, &disk_entry.temp_blks, sizeof(RStats));
 		memcpy(&entry->exec_time, &disk_entry.exec_time, sizeof(RStats));
 		memcpy(&entry->f_join_filter, &disk_entry.f_join_filter, sizeof(RStats));
 		memcpy(&entry->f_scan_filter, &disk_entry.f_scan_filter, sizeof(RStats));

--- a/pg_track_optimizer.control
+++ b/pg_track_optimizer.control
@@ -2,4 +2,4 @@
 comment = 'Track planning decisions in comparison with execution reality'
 module_pathname = '$libdir/pg_track_optimizer'
 relocatable = true
-default_version = '0.9.1'
+default_version = '0.9.2'

--- a/plan_error.c
+++ b/plan_error.c
@@ -55,7 +55,6 @@ prediction_walker(PlanState *pstate, void *context)
 		foreach_node(SubPlanState, sps, pstate->subPlan)
 		{
 			Instrumentation	   *instr = sps->planstate->instrument;
-			double				nloops;
 			double				subplan_time;
 			double				loop_factor;
 			double				cost_factor;
@@ -377,24 +376,23 @@ plan_error(QueryDesc *queryDesc, PlanEstimatorContext *ctx)
 	ctx->njoins = 0;
 
 	/*
-	 * Collect buffer usage statistics from this execution (summarise permanent
-	 * and temp tables blocks types).
+	 * Collect buffer usage statistics from this execution (summarise permanent,
+	 * local and temp tables blocks types).
 	 * For the sake of optimisation preciseness we don't differ blocks found in
 	 * memory and fetched from the disk - the optimiser doesn't predict that.
 	 */
 	ctx->blks_accessed = queryDesc->totaltime->bufusage.shared_blks_hit +
 						 queryDesc->totaltime->bufusage.shared_blks_read +
-						 queryDesc->totaltime->bufusage.temp_blks_read +
-						 queryDesc->totaltime->bufusage.temp_blks_written;
+						 queryDesc->totaltime->bufusage.local_blks_hit +
+						 queryDesc->totaltime->bufusage.local_blks_read +
+						 queryDesc->totaltime->bufusage.temp_blks_read;
 
 	/*
-	 * Collect local blocks statistics separately to help identify work_mem issues.
-	 * Local blocks indicate temporary tables/sorts spilling to disk, suggesting
-	 * insufficient work_mem rather than optimization/statistics errors.
+	 * Collect temp blocks written separately to help identify work_mem
+	 * issues. Temp blocks written indicate sorts/hash joins spilling to disk,
+	 * suggesting insufficient work_mem rather than optimization errors.
 	 */
-	ctx->local_blks = queryDesc->totaltime->bufusage.local_blks_read +
-					  queryDesc->totaltime->bufusage.local_blks_written +
-					  queryDesc->totaltime->bufusage.local_blks_dirtied;
+	ctx->temp_blks = queryDesc->totaltime->bufusage.temp_blks_written;
 
 	/* Initialize JOIN filtering statistics */
 	ctx->f_join_filter = 0.;

--- a/plan_error.h
+++ b/plan_error.h
@@ -50,7 +50,7 @@ typedef struct PlanEstimatorContext
 
 	/* Buffer usage statistics for this query execution */
 	int64	blks_accessed;	/* Sum of all block hits, reads, and writes */
-	int64	local_blks;		/* Local blocks (read + written + dirtied) - indicates work_mem issues */
+	int64	temp_blks;		/* Temp blocks (read + written) - indicates work_mem issues */
 
 	/* JOIN filtering statistics */
 	double	f_join_filter;


### PR DESCRIPTION
Replace the local_blks metric with temp_blks to correctly track work_mem pressure. Local blocks (used by temporary tables) were incorrectly treated as a work_mem indicator; temp blocks written (sorts/hash joins spilling to disk) are the actual signal. Also add local buffer hits and reads to blks_accessed for completeness, and exclude temp_blks_written from blks_accessed since it is now tracked separately.

Dump version number to 0.9.2